### PR TITLE
Document the appElement prop for modals

### DIFF
--- a/src/Modal/doc/Modal.md
+++ b/src/Modal/doc/Modal.md
@@ -2,7 +2,7 @@ Modals are meant to "take over" the screen and focus users attention on a dialog
 
 Note: A modal requires the `appElement` prop to be aria-compliant. Details on how to set this property can be found at http://reactcommunity.org/react-modal/accessibility/
 
-Example: Create a DOM element dynamically and passing it via `appElement` prop to `Modal`
+Example: Create a DOM element dynamically and pass it via `appElement` prop to `Modal`
 
 **`ModalExample.js`**
 
@@ -20,7 +20,7 @@ export class ModalExample extends React.Component {
 }
 ` 
 
-Example: Passing an existing DOM element via `appElement`prop to `Modal`
+Example: Pass an existing DOM element via `appElement` prop to `Modal`
 
 **`index.html`**
 


### PR DESCRIPTION
* Added some documentation for the `appElement` prop on Modals

There's not much to the documentation... What do we want to say? Perhaps we should go into more detail about what element should be passed? Or we can just rely on the documentation from react-modal?