### PR TITLE
Add documentation for imageStyle prop

### DIFF
--- a/src/TopNav/TopNavBrand.js
+++ b/src/TopNav/TopNavBrand.js
@@ -14,7 +14,9 @@ const TopNavBrand = ({ children, href, src, alt, imageStyle, ...other }) => {
 
 TopNavBrand.propTypes = {
   /** Description TBD */
-  children: PropTypes.node
+  children: PropTypes.node,
+  /** Style property for the underlying img element */
+  imageStyle: PropTypes.object
 };
 
 TopNavBrand.defaultProps = {


### PR DESCRIPTION
Added `imageStyle` prop to docs for `TopNavBrand`.

There are probably a few more of these floating around, let me know if you find anymore missing props in the docs!