### PR TITLE
Search Custom Items

### DIFF
--- a/src/Search/Search-styled.js
+++ b/src/Search/Search-styled.js
@@ -7,7 +7,7 @@ const StyledSearchContainer = styled.div`
   align-items: center;
   position: relative;
 
-  .mdi-icon {
+  .mdi-icon.search-magnify-icon {
     position: absolute;
     bottom: 0.45em;
     left: 0.25em;
@@ -25,9 +25,9 @@ const StyledSearchContainer = styled.div`
 
   .mdi-icon.search-close-icon {
     display: none;
+    position: absolute;
     right: ${props => unitCalc(props.theme.baseline, 4, '/')};
     bottom: 0.55em;
-    left: auto;
     width: 18px;
     height: 18px;
     fill: ${props => props.theme.palette.lightGray};

--- a/src/Search/doc/Search-story.js
+++ b/src/Search/doc/Search-story.js
@@ -8,6 +8,11 @@ import doc from './Search.md';
 
 import Search from '../';
 
+import { MenuItem } from '../../Menu';
+import { ListItem, ListItemTitle, ListItemSubtitle } from '../../List';
+
+import ThumbUpIcon from 'mdi-react/ThumbUpIcon';
+
 import statesJson from '../../../stories/_sampleJson/states.json';
 import statesJson2 from '../../../stories/_sampleJson/states_objects.json';
 
@@ -146,18 +151,165 @@ storiesOf('Search', module)
                   menuStyle={{ maxHeight: '400px' }}
                 />
               </GuideExample>
+            </Fragment>
+          );
+        }
+      }
+
+      SearchStory.propTypes = {
+        isStory: PropTypes.bool
+      };
+      return <SearchStory />;
+    })
+  )
+
+  .add(
+    'Child Items',
+    withInfo({
+      text: doc,
+      propTables: [Search]
+    })(() => {
+      class SearchStory extends Component {
+        items = [...statesJson2.states];
+
+        constructor(props) {
+          super(props);
+
+          this.state = {
+            inputValue: '',
+            selectedItem: ''
+          };
+
+          this.dataSourceConfig = {
+            label: 'name',
+            value: 'abbrev'
+          };
+        }
+
+        searchChanged = e => {
+          this.setState({
+            selectedItem: e
+          });
+        };
+
+        clearSearch = () => {
+          this.setState({
+            inputValue: '',
+            selectedItem: ''
+          });
+        };
+
+        onUserAction = (inputValue, selectedItemVal) => {
+          this.setState({
+            inputValue: inputValue,
+            selectedItem: selectedItemVal
+          });
+        };
+
+        render() {
+          return (
+            <Fragment>
               <GuideExample>
                 <Search
                   dataSourceConfig={this.dataSourceConfig}
                   inputValue={this.state.inputValue}
                   selectedItem={this.state.selectedItem}
-                  items={this.items}
-                  minimal={true}
                   onChange={this.searchChanged}
                   onUserAction={this.onUserAction}
                   onRequestClear={this.clearSearch}
                   menuStyle={{ maxHeight: '400px' }}
-                />
+                >
+                  {this.items.map(item => {
+                    return (
+                      <MenuItem key={item.abbrev} item={item}>
+                        {item.name}
+                      </MenuItem>
+                    );
+                  })}
+                </Search>
+              </GuideExample>
+            </Fragment>
+          );
+        }
+      }
+
+      SearchStory.propTypes = {
+        isStory: PropTypes.bool
+      };
+      return <SearchStory />;
+    })
+  )
+
+  .add(
+    'Custom Items',
+    withInfo({
+      text: doc,
+      propTables: [Search]
+    })(() => {
+      class SearchStory extends Component {
+        items = [...statesJson2.states];
+
+        constructor(props) {
+          super(props);
+
+          this.state = {
+            inputValue: '',
+            selectedItem: ''
+          };
+
+          this.dataSourceConfig = {
+            label: 'name',
+            value: 'abbrev'
+          };
+        }
+
+        searchChanged = e => {
+          console.log(e);
+          this.setState({
+            selectedItem: e
+          });
+        };
+
+        clearSearch = () => {
+          this.setState({
+            inputValue: '',
+            selectedItem: ''
+          });
+        };
+
+        onUserAction = (inputValue, selectedItemVal) => {
+          this.setState({
+            inputValue: inputValue,
+            selectedItem: selectedItemVal
+          });
+        };
+
+        render() {
+          return (
+            <Fragment>
+              <GuideExample>
+                <Search
+                  inputValue={this.state.inputValue}
+                  selectedItem={this.state.selectedItem}
+                  onChange={this.searchChanged}
+                  onUserAction={this.onUserAction}
+                  onRequestClear={this.clearSearch}
+                  menuStyle={{ maxHeight: '400px' }}
+                >
+                  {this.items.map(item => {
+                    return (
+                      <ListItem
+                        key={item.abbrev}
+                        value={item.abbrev}
+                        label={item.name}
+                        leftNode={<ThumbUpIcon />}
+                      >
+                        <ListItemTitle>{item.name}</ListItemTitle>
+                        <ListItemSubtitle>{item.abbrev}</ListItemSubtitle>
+                      </ListItem>
+                    );
+                  })}
+                </Search>
               </GuideExample>
             </Fragment>
           );


### PR DESCRIPTION
* Add functionality to `Search` to allow custom menu items as children
* Update stories for examples of items with item prop or label and value props manually set