### PR TITLE
0.20.2

### DIFF
--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -25,10 +25,11 @@ const DatePicker = ({
   children,
   ...other
 }) => {
-  let isSubmitting, setFieldValue, setTouched;
+  let touched, isSubmitting, setFieldValue, setTouched;
   if (field) {
     value = field.value;
     name = field.name;
+    touched = form.touched;
     isSubmitting = form.isSubmitting;
     setFieldValue = form.setFieldValue;
     setTouched = form.setTouched;
@@ -46,7 +47,7 @@ const DatePicker = ({
 
   const _onFocusChange = options => {
     if (setTouched && !options.focused) {
-      setTouched({ [name]: true });
+      setTouched({ ...touched, [name]: true });
     }
 
     if (onFocusChange) {

--- a/src/DatePicker/DateRangePicker.js
+++ b/src/DatePicker/DateRangePicker.js
@@ -25,10 +25,11 @@ const DatePicker = ({
   children,
   ...other
 }) => {
-  let isSubmitting, setFieldValue, setTouched;
+  let touched, isSubmitting, setFieldValue, setTouched;
   if (field) {
     value = field.value;
     name = field.name;
+    touched = form.touched;
     isSubmitting = form.isSubmitting;
     setFieldValue = form.setFieldValue;
     setTouched = form.setTouched;
@@ -50,7 +51,7 @@ const DatePicker = ({
 
   const _onFocusChange = focusedInput => {
     if (setTouched && !focusedInput) {
-      setTouched({ [name]: true });
+      setTouched({ ...touched, [name]: true });
     }
 
     if (onFocusChange) {

--- a/src/FileUploader/FileUploader.js
+++ b/src/FileUploader/FileUploader.js
@@ -26,7 +26,7 @@ const FileUploader = ({
 
   const handleChange = e => {
     if (setFieldValue) {
-      setTouched({ [name]: true });
+      setTouched({ ...touched, [name]: true });
       setFieldValue(name, e.currentTarget.files);
     }
 

--- a/src/Select/Select.js
+++ b/src/Select/Select.js
@@ -120,7 +120,7 @@ const Select = ({
     const value = selectedItem.props.value;
 
     if (setFieldValue) {
-      setTouched({ [name]: true });
+      setTouched({ ...touched, [name]: true });
       setFieldValue(name, value);
     }
 


### PR DESCRIPTION
Fixes usage of formik's `setTouched` method.

We were using `setTouched` as if it handled mixing in the existing `touched` state for us, but we need to imperatively spread existing `touched` when using the method.

Broken:
```js
setTouched({ [name]: true });
```

Fixed:
```js
setTouched({ ...touched, [name]: true });
```