### PR TITLE
Popper Content Rendering

### DIFF
--- a/src/MultiSelect/MultiSelect.js
+++ b/src/MultiSelect/MultiSelect.js
@@ -299,17 +299,6 @@ const Select = ({
                             highlightedIndex,
                             selectedValues
                           })}
-                          {/*Children.map(children, (child, index) =>
-                            React.cloneElement(child, {
-                              ...getItemProps({
-                            item: child,
-                            active: highlightedIndex === index,
-                            selected:
-                            selectedValues.indexOf(child.props.value) > -1
-                              }),
-                              key: index
-                            })
-                          )*/}
                         </StyledMultiSelectMenu>
                       )}
                     </Popper>,

--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -63,7 +63,6 @@ class Popover extends Component {
   };
 
   _handleOutsideTap = e => {
-    console.log(`${this._generatedId}Popover`);
     this.props.onRequestClose(e);
   };
 
@@ -93,43 +92,45 @@ class Popover extends Component {
               </StyledTargetWrapper>
             )}
           </Reference>
-          <Transition in={this.props.open} timeout={0}>
-            {state =>
-              this._getPopper(
-                <Popper
-                  positionFixed={this.props.positionFixed}
-                  placement={this.props.placement}
-                  modifiers={{
-                    preventOverflow: {
-                      enabled: usePreventOverflow
-                    },
-                    hide: {
-                      enabled: usePreventOverflow
-                    }
-                  }}
-                >
-                  {({ ref, style, placement }) => {
-                    return (
-                      <StyledPopover
-                        ref={ref}
-                        id={`${this._generatedId}Popover`}
-                        style={{
-                          ...style,
-                          ...this.props.style
-                        }}
-                        transitionState={state}
-                        transitionDuration={this.props.transitionDuration}
-                        data-placement={placement}
-                      >
-                        {this.props.children}
-                      </StyledPopover>
-                    );
-                  }}
-                </Popper>,
-                this.props.appendToBody
-              )
-            }
-          </Transition>
+          {this.props.open ? (
+            <Transition in={this.props.open} timeout={0}>
+              {state =>
+                this._getPopper(
+                  <Popper
+                    positionFixed={this.props.positionFixed}
+                    placement={this.props.placement}
+                    modifiers={{
+                      preventOverflow: {
+                        enabled: usePreventOverflow
+                      },
+                      hide: {
+                        enabled: usePreventOverflow
+                      }
+                    }}
+                  >
+                    {({ ref, style, placement }) => {
+                      return (
+                        <StyledPopover
+                          ref={ref}
+                          id={`${this._generatedId}Popover`}
+                          style={{
+                            ...style,
+                            ...this.props.style
+                          }}
+                          transitionState={state}
+                          transitionDuration={this.props.transitionDuration}
+                          data-placement={placement}
+                        >
+                          {this.props.children}
+                        </StyledPopover>
+                      );
+                    }}
+                  </Popper>,
+                  this.props.appendToBody
+                )
+              }
+            </Transition>
+          ) : null}
         </Manager>
       </PopoverContext.Provider>
     );

--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -55,48 +55,50 @@ class Tooltip extends Component {
             </StyledTargetWrapper>
           )}
         </Reference>
-        <Transition in={this.state.open} timeout={this.props.enterDelay}>
-          {state =>
-            this._getPopper(
-              <Popper
-                positionFixed={this.props.positionFixed}
-                placement={this.props.placement}
-                modifiers={{
-                  preventOverflow: {
-                    enabled: usePreventOverflow
-                  },
-                  hide: {
-                    enabled: usePreventOverflow
-                  }
-                }}
-              >
-                {({ ref, style, placement, arrowProps }) => (
-                  <StyledTooltip
-                    ref={ref}
-                    style={{
-                      ...style,
-                      ...this.props.style
-                    }}
-                    transitionState={state}
-                    transitionDuration={this.props.transitionDuration}
-                    data-placement={placement}
-                  >
-                    {this.props.title}
-                    <StyledTooltipArrow
-                      ref={arrowProps.ref}
-                      data-placement={placement}
+        {this.state.open ? (
+          <Transition in={this.state.open} timeout={this.props.enterDelay}>
+            {state =>
+              this._getPopper(
+                <Popper
+                  positionFixed={this.props.positionFixed}
+                  placement={this.props.placement}
+                  modifiers={{
+                    preventOverflow: {
+                      enabled: usePreventOverflow
+                    },
+                    hide: {
+                      enabled: usePreventOverflow
+                    }
+                  }}
+                >
+                  {({ ref, style, placement, arrowProps }) => (
+                    <StyledTooltip
+                      ref={ref}
                       style={{
-                        ...arrowProps.style,
-                        ...this.props.arrowStyle
+                        ...style,
+                        ...this.props.style
                       }}
-                    />
-                  </StyledTooltip>
-                )}
-              </Popper>,
-              this.props.appendToBody
-            )
-          }
-        </Transition>
+                      transitionState={state}
+                      transitionDuration={this.props.transitionDuration}
+                      data-placement={placement}
+                    >
+                      {this.props.title}
+                      <StyledTooltipArrow
+                        ref={arrowProps.ref}
+                        data-placement={placement}
+                        style={{
+                          ...arrowProps.style,
+                          ...this.props.arrowStyle
+                        }}
+                      />
+                    </StyledTooltip>
+                  )}
+                </Popper>,
+                this.props.appendToBody
+              )
+            }
+          </Transition>
+        ) : null}
       </Manager>
     );
   }


### PR DESCRIPTION
Optimize `Popper` implementations so we're not rendering content unless the popper is open. Previously we were simply hiding the content with css.