### PR TITLE
Calcite_Icons.mdx:

### DIFF
--- a/docz/Calcite_Icons.mdx
+++ b/docz/Calcite_Icons.mdx
@@ -34,7 +34,7 @@ import LayerBasemapIcon from 'calcite-ui-icons-react/LayerBasemapIcon';
 
 ### Size
 
-The icons can take a `size` prop to adjust the rendered size of the icon.
+The icons take an optional `size` prop to adjust the rendered size of the icon.
 Calcite UI Icons has three unique SVGs for varying sizes for every icon, and we
 automatically select an icon for you based on the size you specify.
 
@@ -70,7 +70,7 @@ we will set it to "currentColor".
 
 ### Gotchas
 
-Since JavaScript variables cannot start with a number - we convert any icon name
+Since JavaScript variables cannot start with a number, we convert any icon name
 that begins with a number so that the word (or words, in PascalCase) are used
 instead.
 

--- a/docz/Customizing_Calcite.mdx
+++ b/docz/Customizing_Calcite.mdx
@@ -31,9 +31,9 @@ export default App;
 
 ### Using Theme Variables
 
-As part of extending Calcite React components you also gain access to the full
-[Theme Object](https://github.com/ArcGIS/calcite-react/blob/master/src/CalciteThemeProvider/CalciteTheme.js)
-, this includes colors, baseline measurements, border-radius, etc.
+As part of extending Calcite React components, you also gain access to the full
+[Theme Object](https://github.com/ArcGIS/calcite-react/blob/master/src/CalciteThemeProvider/CalciteTheme.js).
+This includes colors, baseline measurements, border-radius, etc.
 
 ```jsx
 const ExtendedButton = styled(Button)`

--- a/docz/Getting_Started.mdx
+++ b/docz/Getting_Started.mdx
@@ -52,7 +52,7 @@ Below is a simple example of importing and using two Calcite React components.
 import React, { Component } from 'react';
 
 import Button from 'calcite-react/Button';
-import { CalciteH1 } from 'calcilte-react/Elements';
+import { CalciteH1 } from 'calcite-react/Elements';
 
 class App extends Component {
   render() {


### PR DESCRIPTION
Getting_Started.mdx:
calcilte --> calcite

Customizing_Calcite.mdx:
Comma/Sentence restructure

Calcite_Icons.mdx:
### Size section - this isn't wrong; had a gut reaction that I can't defend objectively.

These are the sole 3 *.mdx files I have, are there others missing?