### PR TITLE
Edits:

### DIFF
--- a/src/Accordion/Accordion.js
+++ b/src/Accordion/Accordion.js
@@ -31,9 +31,9 @@ const Accordion = ({
 };
 
 Accordion.propTypes = {
-  /** Used to render AccordionSections inside the Accordion */
+  /** Used to render AccordionSections inside the Accordion. */
   children: PropTypes.node,
-  /** Indexes of the sections that are supposed to be active */
+  /** Indexes of the sections that are supposed to be active. */
   activeSectionIndexes: PropTypes.array
 };
 

--- a/src/Accordion/AccordionContent.js
+++ b/src/Accordion/AccordionContent.js
@@ -7,7 +7,7 @@ const AccordionContent = ({ children, ...other }) => {
 };
 
 AccordionContent.propTypes = {
-  /** The content of the component, can be a node or string */
+  /** The content of the component; can be a node or string. */
   children: PropTypes.node
 };
 

--- a/src/Accordion/AccordionSection.js
+++ b/src/Accordion/AccordionSection.js
@@ -44,7 +44,7 @@ const AccordionSection = ({
 };
 
 AccordionSection.propTypes = {
-  /** The content of the component, should be AccordionTitle and AccordionContent */
+  /** The content of the component; should be AccordionTitle and AccordionContent. */
   children: PropTypes.node
 };
 

--- a/src/ArcgisAccount/ArcgisAccount.js
+++ b/src/ArcgisAccount/ArcgisAccount.js
@@ -117,17 +117,17 @@ class ArcgisAccount extends Component {
 }
 
 ArcgisAccount.propTypes = {
-  /** AGOL user object */
+  /** AGOL user object. */
   user: PropTypes.object.isRequired,
-  /** AGOL portal object */
+  /** AGOL portal object. */
   portal: PropTypes.object.isRequired,
-  /** AGOL login token */
+  /** AGOL login token. */
   token: PropTypes.string,
-  /** Hide the button to switch accounts in the menu */
+  /** Hide the button to switch accounts in the menu. */
   hideSwitchAccount: PropTypes.bool,
-  /** Callback when the user selects the Switch Account button */
+  /** Callback when the user selects the Switch Account button. */
   onRequestSwitchAccount: PropTypes.func,
-  /** Callback when the user selects the Sign Out button */
+  /** Callback when the user selects the Sign Out button. */
   onRequestSignOut: PropTypes.func
 };
 

--- a/src/ArcgisAccount/ArcgisAccountControl.js
+++ b/src/ArcgisAccount/ArcgisAccountControl.js
@@ -46,13 +46,13 @@ const ArcgisAccountControl = ({
 };
 
 ArcgisAccountControl.propTypes = {
-  /** User profile avatar image */
+  /** User profile avatar image. */
   avatar: PropTypes.node,
-  /** User's full name */
+  /** User's full name. */
   fullName: PropTypes.string,
-  /** User's AGOL username */
+  /** User's AGOL username. */
   username: PropTypes.string,
-  /** Boolean toggle for popover visibility */
+  /** Boolean toggle for popover visibility. */
   open: PropTypes.bool
 };
 

--- a/src/ArcgisAccount/ArcgisAccountMenu.js
+++ b/src/ArcgisAccount/ArcgisAccountMenu.js
@@ -67,11 +67,11 @@ const ArcgisAccountMenu = ({
 };
 
 ArcgisAccountMenu.propTypes = {
-  /** AGOL user object */
+  /** AGOL user object. */
   user: PropTypes.object,
-  /** Text label for the Switch Account button */
+  /** Text label for the Switch Account button. */
   switchAccountLabel: PropTypes.string,
-  /** Text label for the Sign Out button */
+  /** Text label for the Sign Out button. */
   signOutLabel: PropTypes.string
 };
 

--- a/src/ArcgisAccount/ArcgisAccountMenuItem.js
+++ b/src/ArcgisAccount/ArcgisAccountMenuItem.js
@@ -24,7 +24,7 @@ const ArcgisAccountMenuItem = ({ children, ...other }) => {
 };
 
 ArcgisAccountMenuItem.propTypes = {
-  /** Content node of the menu item */
+  /** Content node of the ArcgisAccountMenuItem. */
   children: PropTypes.node
 };
 

--- a/src/ArcgisItemCard/ArcgisItemCard.js
+++ b/src/ArcgisItemCard/ArcgisItemCard.js
@@ -86,13 +86,13 @@ const ArcgisItemCard = ({
 };
 
 ArcgisItemCard.propTypes = {
-  /** The ArcGIS item used to populate the ui */
+  /** The ArcGIS item used to populate the UI. */
   item: PropTypes.object,
-  /** Whether the card should show a thumbnail or not */
+  /** Whether the ArcgisItemCard should show a thumbnail or not. */
   showThumbnail: PropTypes.bool,
-  /** A function that can be provided to customize the formatting of dates */
+  /** A function that can be provided to customize the formatting of dates. */
   dateFormatter: PropTypes.func,
-  /** Number of characters to use before truncating the description text */
+  /** Number of characters to use before truncating the description text. */
   maxDescriptionLength: PropTypes.number
 };
 

--- a/src/ArcgisShare/ArcgisShare.js
+++ b/src/ArcgisShare/ArcgisShare.js
@@ -153,17 +153,17 @@ class ArcgisShare extends Component {
 }
 
 ArcgisShare.propTypes = {
-  /** AGOL user object */
+  /** AGOL user object. */
   user: PropTypes.object.isRequired,
-  /** AGOL portal object */
+  /** AGOL portal object. */
   portal: PropTypes.object.isRequired,
-  /** AGOL sharing object */
+  /** AGOL sharing object. */
   sharing: PropTypes.object,
-  /** Text label for the Public group */
+  /** Text label for the Public group. */
   publicLabel: PropTypes.string,
-  /** Text label for the Groups header */
+  /** Text label for the Groups header. */
   groupsLabel: PropTypes.string,
-  /** Boolean toggle for highlighting favorited groups */
+  /** Boolean toggle for highlighting favorited groups. */
   promoteFavorites: PropTypes.bool
 };
 

--- a/src/ArcgisShare/doc/ArcgisShare.md
+++ b/src/ArcgisShare/doc/ArcgisShare.md
@@ -1,1 +1,1 @@
-A checkbox tree to select what groups you want to share an item with in ArcGIS.
+A checkbox tree to select which groups you want to share an item with in ArcGIS.

--- a/src/ArcgisShare/doc/ArcgisShare.mdx
+++ b/src/ArcgisShare/doc/ArcgisShare.mdx
@@ -13,7 +13,7 @@ import item from './item.json';
 
 # ArcgisShare
 
-A checkbox tree to select what groups you want to share an item with in ArcGIS.
+A checkbox tree to select which groups you want to share an item with in ArcGIS.
 
 ## Basic Usage
 

--- a/src/Avatar/Avatar.js
+++ b/src/Avatar/Avatar.js
@@ -45,14 +45,14 @@ const Avatar = ({
 };
 
 Avatar.propTypes = {
-  /** The content of the component, can take text, an image, or an icon */
+  /** The content of the component; can take text, an image, or an icon. */
   children: PropTypes.node,
-  /** The src attribute for the img element */
+  /** The src attribute for the img element. */
   src: PropTypes.string,
   /** Used in combination with src to provide
-   an alt attribute for the rendered img element */
+   an alt attribute for the rendered img element. */
   alt: PropTypes.string,
-  /** Diameter of the avatar */
+  /** Diameter of the Avatar. */
   size: PropTypes.number
 };
 

--- a/src/Breadcrumbs/Crumb.js
+++ b/src/Breadcrumbs/Crumb.js
@@ -22,9 +22,9 @@ const Crumb = ({ children, href, hasLink, ...other }) => {
 };
 
 Crumb.propTypes = {
-  /** Text content of the bread crumb */
+  /** Text content of the Breadcrumb. */
   children: PropTypes.node,
-  /** Boolean to toggle the light style for breadcrumbs */
+  /** Boolean to toggle the light style for Breadcrumbs. */
   white: PropTypes.bool,
   /** href html prop */
   href: PropTypes.string

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -59,45 +59,45 @@ const Button = ({
 };
 
 Button.propTypes = {
-  /** The content of the component, text or icon */
+  /** The content of the component; text or icon. */
   children: PropTypes.node,
-  /** The html type property of the Button */
+  /** The HTML type property of the Button. */
   type: PropTypes.oneOf(['button', 'reset', 'submit']),
-  /** Style prop used to render a transparent button */
+  /** Style prop used to render a transparent Button. */
   transparent: PropTypes.bool,
-  /** Style prop used to render a clear button */
+  /** Style prop used to render a clear Button. */
   clear: PropTypes.bool,
-  /** Style prop used to render a clear-gray button */
+  /** Style prop used to render a clear-gray Button. */
   clearGray: PropTypes.bool,
-  /** Style prop used to render a clear-white button */
+  /** Style prop used to render a clear-white Button. */
   clearWhite: PropTypes.bool,
-  /** Style prop used to render a white button */
+  /** Style prop used to render a white Button. */
   white: PropTypes.bool,
-  /** Style prop used to render an extra small button */
+  /** Style prop used to render an extra small Button. */
   extraSmall: PropTypes.bool,
-  /** Style prop used to render a small button */
+  /** Style prop used to render a small Button. */
   small: PropTypes.bool,
-  /** Style prop used to render a large button */
+  /** Style prop used to render a large Button. */
   large: PropTypes.bool,
-  /** Style prop used to render an extra large button */
+  /** Style prop used to render an extra large Button. */
   extraLarge: PropTypes.bool,
-  /** Style prop used to render a 100% width button */
+  /** Style prop used to render a 100% width Button. */
   fullWidth: PropTypes.bool,
-  /** Style prop used to render a 50% width button */
+  /** Style prop used to render a 50% width Button. */
   half: PropTypes.bool,
-  /** Style prop used to render a red button */
+  /** Style prop used to render a red Button. */
   red: PropTypes.bool,
-  /** Style prop used to render a green button */
+  /** Style prop used to render a green Button. */
   green: PropTypes.bool,
-  /** The html disabled property of the Button */
+  /** The HTML disabled property of the Button. */
   disabled: PropTypes.bool,
-  /** The html href property of the Button */
+  /** The HTML href property of the Button. */
   href: PropTypes.string,
-  /** The icon that will be displayed as the content of a Button */
+  /** The icon that will be displayed as the content of a Button. */
   icon: PropTypes.node,
-  /** A style prop used to adjust size and padding of buttons with only an icon as its content */
+  /** A style prop used to adjust size and padding of Buttons with only an icon as its content. */
   iconButton: PropTypes.bool,
-  /** The position of the icon in relation to other children in a Button */
+  /** The position of the icon in relation to other children in a Button. */
   iconPosition: PropTypes.oneOf(['after', 'before'])
 };
 

--- a/src/Button/ButtonGroup.js
+++ b/src/Button/ButtonGroup.js
@@ -25,9 +25,9 @@ const ButtonGroup = ({ children, isToggle, ...other }) => {
 };
 
 ButtonGroup.propTypes = {
-  /** The content of the component, should be a number of Buttons */
+  /** The content of the component; should be a number of Buttons. */
   children: PropTypes.node,
-  /** Style prop used to help adjust margins and positioning of buttons when one is active */
+  /** Style prop used to help adjust margins and positioning of Buttons when one is active. */
   isToggle: PropTypes.bool
 };
 

--- a/src/Card/Card.js
+++ b/src/Card/Card.js
@@ -25,13 +25,13 @@ const Card = forwardRef(({ children, shaped, wide, ...other }, ref) => {
 });
 
 Card.propTypes = {
-  /** The content of the component */
+  /** The content of the component. */
   children: PropTypes.node,
-  /** Style prop to show a colored bar across the top of the Card, can take a string for any color name in EsriColors */
+  /** Style prop to show a colored bar across the top of the Card; can take a string for any color name in EsriColors. */
   bar: PropTypes.string,
-  /** Style prop to add a shape mask to the CardImage */
+  /** Style prop to add a shape mask to the CardImage. */
   shaped: PropTypes.bool,
-  /** Style prop to position Card content horizontally and fill the width of its container */
+  /** Style prop to position Card content horizontally and fill the width of its container. */
   wide: PropTypes.bool
 };
 

--- a/src/Card/CardContent.js
+++ b/src/Card/CardContent.js
@@ -17,7 +17,7 @@ const CardContent = ({ children, ...other }) => {
 };
 
 CardContent.propTypes = {
-  /** The content of the component */
+  /** The content of the component. */
   children: PropTypes.node
 };
 

--- a/src/Card/CardImage.js
+++ b/src/Card/CardImage.js
@@ -28,11 +28,11 @@ const CardImage = ({ children, src, caption, alt, ...other }) => {
 };
 
 CardImage.propTypes = {
-  /** The html src property of the CardImage */
+  /** The HTML src property of the CardImage. */
   src: PropTypes.string,
-  /** The text content of the figure caption on the CardImage */
+  /** The text content of the figure caption on the CardImage. */
   caption: PropTypes.string,
-  /** The html alt property of the component */
+  /** The HTML alt property of the component. */
   alt: PropTypes.string
 };
 

--- a/src/Card/CardTitle.js
+++ b/src/Card/CardTitle.js
@@ -7,7 +7,7 @@ const CardTitle = ({ children, ...other }) => {
 };
 
 CardTitle.propTypes = {
-  /** The content of the component */
+  /** The content of the component. */
   children: PropTypes.node
 };
 

--- a/src/Card/doc/Card.mdx
+++ b/src/Card/doc/Card.mdx
@@ -136,7 +136,7 @@ information.
         in landscape orientation. This is useful in situations where there is
         too much content to display well in a standard card.
       </p>
-      <p>Generally wide cards are meant to be displayed one-up, not grouped.</p>
+      <p>Generally, wide cards are meant to be displayed one-up, not grouped.</p>
     </CardContent>
   </Card>
 </Playground>

--- a/src/Checkbox/Checkbox.js
+++ b/src/Checkbox/Checkbox.js
@@ -100,17 +100,17 @@ const Checkbox = ({
 };
 
 Checkbox.propTypes = {
-  /** The label text of the Checkbox */
+  /** The label text of the Checkbox. */
   children: PropTypes.node,
-  /** The form value for this checkbox */
+  /** The form value for this Checkbox. */
   value: PropTypes.string,
-  /** The name to be shared among checkboxes in a group */
+  /** The name to be shared among Checkboxes in a group. */
   name: PropTypes.string,
-  /** Whether the checkbox is currently checked */
+  /** Whether the Checkbox is currently checked. */
   checked: PropTypes.bool,
-  /** Style object passed down to the label */
+  /** Style object passed down to the label. */
   labelStyle: PropTypes.object,
-  /** Event called when the checkbox value should be toggled */
+  /** Event called when the Checkbox value should be toggled. */
   onChange: PropTypes.func
 };
 

--- a/src/ComboButton/ComboButton.js
+++ b/src/ComboButton/ComboButton.js
@@ -82,37 +82,37 @@ class ComboButton extends Component {
 }
 
 ComboButton.propTypes = {
-  /** The content of the component, should be a Menu with MenuItems for the dropdown */
+  /** The content of the component; should be a Menu with MenuItems for the dropdown. */
   children: PropTypes.node,
-  /** The html type property of the primary button */
+  /** The HTML type property of the primary ComboButton. */
   type: PropTypes.oneOf(['button', 'reset', 'submit']),
-  /** Style prop used to render a clear button */
+  /** Style prop used to render a clear ComboButton. */
   clear: PropTypes.bool,
-  /** Style prop used to render a clear-gray button */
+  /** Style prop used to render a clear-gray ComboButton. */
   clearGray: PropTypes.bool,
-  /** Style prop used to render an extra small button */
+  /** Style prop used to render an extra small ComboButton. */
   extraSmall: PropTypes.bool,
-  /** Style prop used to render a small button */
+  /** Style prop used to render a small ComboButton. */
   small: PropTypes.bool,
-  /** Style prop used to render a large button */
+  /** Style prop used to render a large ComboButton. */
   large: PropTypes.bool,
-  /** Style prop used to render an extra large button */
+  /** Style prop used to render an extra large ComboButton. */
   extraLarge: PropTypes.bool,
-  /** Style prop used to render a 100% width button */
+  /** Style prop used to render a 100% width ComboButton. */
   fullWidth: PropTypes.bool,
-  /** Style prop used to render a 50% width button */
+  /** Style prop used to render a 50% width ComboButton. */
   half: PropTypes.bool,
-  /** Style prop used to render a red button */
+  /** Style prop used to render a red ComboButton. */
   red: PropTypes.bool,
-  /** Style prop used to render a green button */
+  /** Style prop used to render a green ComboButton. */
   green: PropTypes.bool,
-  /** The html disabled property of the primary button */
+  /** The HTML disabled property of the primary ComboButton. */
   disabled: PropTypes.bool,
-  /** The html href property of the primary button, results in rendering an anchor element */
+  /** The HTML href property of the primary ComboButton; results in rendering an anchor element. */
   href: PropTypes.string,
-  /** The icon that will be displayed as the content of a ComboButton */
+  /** The icon that will be displayed as the content of a ComboButton. */
   icon: PropTypes.node,
-  /** The position of the icon in relation to other children in a ComboButton */
+  /** The position of the icon in relation to other children in a ComboButton. */
   iconPosition: PropTypes.oneOf(['after', 'before'])
 };
 

--- a/src/CopyToClipboard/CopyToClipboard.js
+++ b/src/CopyToClipboard/CopyToClipboard.js
@@ -91,11 +91,11 @@ class CopyToClipboard extends Component {
 }
 
 CopyToClipboard.propTypes = {
-  /** Text to be copied */
+  /** Text to be copied. */
   children: PropTypes.string,
-  /** The tooltip label before the text is copied */
+  /** The tooltip label before the text is copied. */
   tooltip: PropTypes.string,
-  /** The tooltip label after the text is copied */
+  /** The tooltip label after the text is copied. */
   successTooltip: PropTypes.string
 };
 

--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -69,17 +69,17 @@ const DatePicker = ({
 };
 
 DatePicker.propTypes = {
-  /** The currently selected moment date object for the component */
+  /** The currently selected moment date object for the component. */
   date: momentPropTypes.momentObj,
-  /** Callback function when the selected date is changed */
+  /** Callback function when the selected date is changed. */
   onDateChange: PropTypes.func.isRequired,
-  /** Describe whether the DatePicker is currently focused, displays the calendar dropdown */
+  /** Describe whether the DatePicker is currently focused; displays the calendar dropdown. */
   focused: PropTypes.bool,
-  /** Callback function when the focus state of the DatePicker is changed */
+  /** Callback function when the focus state of the DatePicker is changed. */
   onFocusChange: PropTypes.func.isRequired,
-  /** Placeholder text for the Datepicker textfield */
+  /** Placeholder text for the DatePicker text field. */
   placeholder: PropTypes.string,
-  /** An id supplied to the DatePicker */
+  /** An id supplied to the DatePicker. */
   id: PropTypes.string.isRequired
 };
 

--- a/src/DatePicker/DateRangePicker.js
+++ b/src/DatePicker/DateRangePicker.js
@@ -74,23 +74,23 @@ const DateRangePicker = ({
 };
 
 DateRangePicker.propTypes = {
-  /** The currently selected moment date object for the start date */
+  /** The currently selected moment date object for the start date. */
   startDate: momentPropTypes.momentObj,
-  /** Id provided to the start date text field */
+  /** Id provided to the start date text field. */
   startDateId: PropTypes.string.isRequired,
-  /** The currently selected moment date object for the end date */
+  /** The currently selected moment date object for the end date. */
   endDate: momentPropTypes.momentObj,
-  /** Id provided to the end date text field */
+  /** Id provided to the end date text field. */
   endDateId: PropTypes.string.isRequired,
-  /** Callback function when the start or end date is changed */
+  /** Callback function when the start or end date is changed. */
   onDatesChange: PropTypes.func.isRequired,
-  /** The name of the currently focused text field */
+  /** The name of the currently focused text field. */
   focusedInput: PropTypes.oneOf(['startDate', 'endDate']),
-  /** Callback function when the focused input is changed */
+  /** Callback function when the focused input is changed. */
   onFocusChange: PropTypes.func.isRequired,
-  /** Placeholder text for the start date text field */
+  /** Placeholder text for the start date text field. */
   startDatePlaceholderText: PropTypes.string,
-  /** Placeholder text for the end date text field */
+  /** Placeholder text for the end date text field. */
   endDatePlaceholderText: PropTypes.string
 };
 

--- a/src/Drawer/Drawer.js
+++ b/src/Drawer/Drawer.js
@@ -35,17 +35,17 @@ const Drawer = ({
 };
 
 Drawer.propTypes = {
-  /** Child elements to be rendered inside the Drawer */
+  /** Child elements to be rendered inside the Drawer. */
   children: PropTypes.node,
-  /** Toggle visibility of the drawer */
+  /** Toggle visibility of the Drawer. */
   active: PropTypes.bool,
-  /** Display the drawer on the right side of the screen */
+  /** Display the Drawer on the right side of the screen. */
   right: PropTypes.bool,
-  /** Width (in px) of the drawer nav */
+  /** Width (in px) of the Drawer nav. */
   drawerWidth: PropTypes.number,
-  /** Function called when the user clicks the overlay area of a drawer */
+  /** Function called when the user clicks the overlay area of a Drawer. */
   onRequestClose: PropTypes.func,
-  /** Styles passed to the DrawerNav sub-component */
+  /** Styles passed to the DrawerNav subcomponent. */
   drawerNavStyle: PropTypes.node
 };
 

--- a/src/Elements/doc/Elements.md
+++ b/src/Elements/doc/Elements.md
@@ -1,1 +1,1 @@
-Generic html elements
+Generic HTML elements

--- a/src/Elements/doc/Elements.mdx
+++ b/src/Elements/doc/Elements.mdx
@@ -21,7 +21,7 @@ import {
 
 # Elements
 
-Generic html elements
+Generic HTML elements
 
 ## Calcite Headers
 

--- a/src/FileUploader/FileUploader.js
+++ b/src/FileUploader/FileUploader.js
@@ -63,7 +63,7 @@ const FileUploader = ({
 };
 
 FileUploader.propTypes = {
-  /** The callback function when the selected file is changed */
+  /** The callback function when the selected file is changed. */
   onChange: PropTypes.func
 };
 

--- a/src/Form/Fieldset.js
+++ b/src/Form/Fieldset.js
@@ -29,9 +29,9 @@ const Fieldset = ({ children, name, ...other }) => {
 };
 
 Fieldset.propTypes = {
-  /** The content of the component */
+  /** The content of the component. */
   children: PropTypes.node,
-  /** The html name property applied to the radios and checkboxes contained */
+  /** The HTML name property applied to the contained radios and checkboxes. */
   name: PropTypes.string.isRequired
 };
 

--- a/src/Form/Form.js
+++ b/src/Form/Form.js
@@ -17,11 +17,11 @@ const Form = ({ children, noValidation, ...other }) => {
 };
 
 Form.propTypes = {
-  /** The content of the component */
+  /** The content of the component. */
   children: PropTypes.node,
-  /** Display prop to make forms align items horizontally instead of vertically */
+  /** Display prop to make Forms align items horizontally instead of vertically. */
   horizontal: PropTypes.bool,
-  /** If the FormControl doesn't need validation you can set this to true to tighten up the bottom margin */
+  /** If the FormControl doesn't need validation, you can set this to true to tighten up the bottom margin. */
   noValidation: PropTypes.bool
 };
 

--- a/src/Form/FormControl.js
+++ b/src/Form/FormControl.js
@@ -49,15 +49,15 @@ const FormControl = ({
 };
 
 FormControl.propTypes = {
-  /** The content of the component */
+  /** The content of the component. */
   children: PropTypes.node,
-  /** The form control should show an error */
+  /** The FormControl should show an error. */
   error: PropTypes.bool,
-  /** The form control should show success */
+  /** The FormControl should show success. */
   success: PropTypes.bool,
-  /** The form control should layout as horizontal elements */
+  /** The FormControl should layout as horizontal elements. */
   horizontal: PropTypes.bool,
-  /** If the FormControl doesn't need validation you can set this to true to tighten up the bottom margin */
+  /** If the FormControl doesn't need validation, you can set this to true to tighten up the bottom margin. */
   noValidation: PropTypes.bool
 };
 

--- a/src/Form/FormControlLabel.js
+++ b/src/Form/FormControlLabel.js
@@ -23,15 +23,15 @@ const FormControlLabel = ({ children, htmlFor, ...other }) => {
 };
 
 FormControlLabel.propTypes = {
-  /** The text content of the component */
+  /** The text content of the component. */
   children: PropTypes.node,
-  /** The for property to be applied to the label, should match a form element id */
+  /** The for property to be applied to the label; should match a form element id. */
   htmlFor: PropTypes.string,
-  /** The form control label should show an error */
+  /** The FormControlLabel should show an error. */
   error: PropTypes.bool,
-  /** The form control label should show success */
+  /** The FormControlLabel should show success. */
   success: PropTypes.bool,
-  /** Display prop to make this element align items horizontally instead of vertically */
+  /** Display prop to make this element align items horizontally instead of vertically. */
   horizontal: PropTypes.bool
 };
 

--- a/src/Form/FormHelperText.js
+++ b/src/Form/FormHelperText.js
@@ -21,11 +21,11 @@ const FormHelperText = ({ children, ...other }) => {
 };
 
 FormHelperText.propTypes = {
-  /** The text content of the component */
+  /** The text content of the component. */
   children: PropTypes.node,
-  /** The form helper text should display as an error */
+  /** The FormHelperText should display as an error. */
   error: PropTypes.bool,
-  /** The form helper text should display as successful */
+  /** The FormHelperText should display as successful. */
   success: PropTypes.bool
 };
 

--- a/src/Form/Legend.js
+++ b/src/Form/Legend.js
@@ -17,9 +17,9 @@ const Legend = ({ children, ...other }) => {
 };
 
 Legend.propTypes = {
-  /** The content of the component */
+  /** The content of the component. */
   children: PropTypes.node,
-  /** Display prop to make this element align items horizontally instead of vertically */
+  /** Display prop to make this element align items horizontally instead of vertically. */
   horizontal: PropTypes.bool
 };
 

--- a/src/Form/doc/Form.md
+++ b/src/Form/doc/Form.md
@@ -1,5 +1,5 @@
 Labels for form elements should describe what the field is. Labels should not be followed by a semicolon. Placeholder text should describe the specifics about formatting or examples for the input text. Placeholder text is optional, and should never be used to replace a label.
 
-Required form fields should be have the required attribute. While optional form fields should be clearly marked with "(optional)".
+Required form fields should have the required attribute. Optional form fields should be clearly marked with "(optional)".
 
 Try not to include too many optional fields, as it will make the form harder to comprehend and complete for the user.

--- a/src/Form/doc/Form.mdx
+++ b/src/Form/doc/Form.mdx
@@ -25,7 +25,7 @@ import DatePicker from '../../DatePicker';
 
 Labels for form elements should describe what the field is. Labels should not be followed by a semicolon. Placeholder text should describe the specifics about formatting or examples for the input text. Placeholder text is optional, and should never be used to replace a label.
 
-Required form fields should be have the required attribute. While optional form fields should be clearly marked with "(optional)".
+Required form fields should have the required attribute. Optional form fields should be clearly marked with "(optional)".
 
 Try not to include too many optional fields, as it will make the form harder to comprehend and complete for the user.
 

--- a/src/Label/Label.js
+++ b/src/Label/Label.js
@@ -7,15 +7,15 @@ const Label = ({ children, ...other }) => {
 };
 
 Label.propTypes = {
-  /** Content of the label */
+  /** Content of the Label. */
   children: PropTypes.node,
-  /** Blue style label */
+  /** Blue style Label. */
   blue: PropTypes.bool,
-  /** Green style label */
+  /** Green style Label. */
   green: PropTypes.bool,
-  /** Yellow style label */
+  /** Yellow style Label. */
   yellow: PropTypes.bool,
-  /** Red style label */
+  /** Red style Label. */
   red: PropTypes.bool
 };
 

--- a/src/List/List.js
+++ b/src/List/List.js
@@ -47,11 +47,11 @@ class List extends Component {
 }
 
 List.propTypes = {
-  /** The content of the component, can contain ListHeader, ListItem, and even another List */
+  /** The content of the component; can contain ListHeader, ListItem, and even another List. */
   children: PropTypes.node,
-  /** Applied when the list is imbedded inside another list */
+  /** Applied when the List is imbedded inside another List. */
   nested: PropTypes.bool,
-  /** Whether the list should be collapsed or expanded */
+  /** Whether the List should be collapsed or expanded. */
   open: PropTypes.bool
 };
 

--- a/src/List/ListHeader.js
+++ b/src/List/ListHeader.js
@@ -18,7 +18,7 @@ const ListHeader = ({ children, ...other }) => {
 };
 
 ListHeader.propTypes = {
-  /** The content of the component */
+  /** The content of the component. */
   children: PropTypes.node
 };
 

--- a/src/List/ListItem.js
+++ b/src/List/ListItem.js
@@ -44,11 +44,11 @@ const ListItem = ({ children, leftNode, rightNode, ...other }) => {
 };
 
 ListItem.propTypes = {
-  /** Content of the ListItem */
+  /** Content of the ListItem. */
   children: PropTypes.node,
-  /** Content placed to the left of the ListItem */
+  /** Content placed to the left of the ListItem. */
   leftNode: PropTypes.node,
-  /** Content placed to the right of the ListItem */
+  /** Content placed to the right of the ListItem. */
   rightNode: PropTypes.node
 };
 

--- a/src/List/ListItemSubtitle.js
+++ b/src/List/ListItemSubtitle.js
@@ -18,9 +18,9 @@ const ListSubtitle = ({ children, ...other }) => {
 };
 
 ListSubtitle.propTypes = {
-  /** Content of the SubTitle */
+  /** Content of the Subtitle. */
   children: PropTypes.node,
-  /** Applied when the list is imbedded inside another list */
+  /** Applied when the List is imbedded inside another List. */
   nested: PropTypes.bool
 };
 

--- a/src/List/ListItemTitle.js
+++ b/src/List/ListItemTitle.js
@@ -18,9 +18,9 @@ const ListTitle = ({ children, ...other }) => {
 };
 
 ListTitle.propTypes = {
-  /** Content of the ItemTitle */
+  /** Content of the ItemTitle. */
   children: PropTypes.node,
-  /** Applied when the list is imbedded inside another list */
+  /** Applied when the List is imbedded inside another List. */
   nested: PropTypes.bool
 };
 

--- a/src/Loader/Loader.js
+++ b/src/Loader/Loader.js
@@ -23,7 +23,7 @@ const Loader = ({ text, ...other }) => {
 };
 
 Loader.propTypes = {
-  /** Text displayed below the loading bars */
+  /** Text displayed below the loading bars. */
   text: PropTypes.string
 };
 

--- a/src/Loader/doc/Loader.md
+++ b/src/Loader/doc/Loader.md
@@ -1,1 +1,1 @@
-The loader element is a placeholder while content is being retrieved or rendered.
+The Loader element is a placeholder while content is being retrieved or rendered.

--- a/src/Loader/doc/Loader.mdx
+++ b/src/Loader/doc/Loader.mdx
@@ -10,7 +10,7 @@ import Loader from '../';
 
 # Loader
 
-The loader element is a placeholder while content is being retrieved or
+The Loader element is a placeholder while content is being retrieved or
 rendered.
 
 ## Basic Usage

--- a/src/Menu/Menu.js
+++ b/src/Menu/Menu.js
@@ -11,7 +11,7 @@ const Menu = forwardRef(({ children, ...other }, ref) => {
 });
 
 Menu.propTypes = {
-  /** Content node for the Menu */
+  /** Content node for the Menu. */
   children: PropTypes.node
 };
 

--- a/src/Menu/MenuItem.js
+++ b/src/Menu/MenuItem.js
@@ -18,9 +18,9 @@ const MenuItem = ({ children, subtitle, ...other }) => {
 };
 
 MenuItem.propTypes = {
-  /** Content of the MenuItem */
+  /** Content of the MenuItem. */
   children: PropTypes.node,
-  /** A container for content to be displayed right aligned in the menu item */
+  /** A container for content to be displayed right aligned in the MenuItem. */
   subtitle: PropTypes.node
 };
 

--- a/src/Menu/MenuTitle.js
+++ b/src/Menu/MenuTitle.js
@@ -12,7 +12,7 @@ const MenuTitle = ({ children, ...other }) => {
 };
 
 MenuTitle.propTypes = {
-  /** Content of the MenuTitle */
+  /** Content of the MenuTitle. */
   children: PropTypes.node
 };
 

--- a/src/Menu/doc/Menu.md
+++ b/src/Menu/doc/Menu.md
@@ -1,3 +1,3 @@
 Menus are good for showing multiple options under a single call to action. For example, if you had a download button, and you needed the user to choose a format for the download, you could put several choices in a Menu.
 
-Menus differ from select elements in that they don't have a default state or a 'current' state. Instead, they offer a jumping off point for a series of related actions.
+Menus differ from Select elements in that they don't have a default state or a 'current' state. Instead, they offer a jumping off point for a series of related actions.

--- a/src/Menu/doc/Menu.mdx
+++ b/src/Menu/doc/Menu.mdx
@@ -15,7 +15,7 @@ Menus are good for showing multiple options under a single call to action. For
 example, if you had a download button, and you needed the user to choose a
 format for the download, you could put several choices in a Menu.
 
-Menus differ from select elements in that they don't have a default state or a
+Menus differ from Select elements in that they don't have a default state or a
 'current' state. Instead, they offer a jumping off point for a series of related
 actions.
 

--- a/src/Modal/Modal.js
+++ b/src/Modal/Modal.js
@@ -49,25 +49,25 @@ const Modal = ({
 };
 
 Modal.propTypes = {
-  /** The content of the component */
+  /** The content of the component. */
   children: PropTypes.node,
-  /** Boolean describing if the modal should be shown or not. */
+  /** Boolean describing if the Modal should be shown or not. */
   open: PropTypes.bool,
-  /** String indicating how the content container should be announced to screenreaders */
+  /** String indicating how the content container should be announced to screenreaders. */
   title: PropTypes.string,
-  /** Function that will be run after the modal has opened. */
+  /** Function that will be run after the Modal has opened. */
   onAfterOpen: PropTypes.func,
-  /** Function that will be run when the modal is requested to be closed (either by clicking on overlay or pressing ESC) */
+  /** Function that will be run when the Modal is requested to be closed (either by clicking on overlay or pressing ESC). */
   onRequestClose: PropTypes.func,
-  /** Boolean indicating if the overlay should close the modal */
+  /** Boolean indicating if the overlay should close the Modal. */
   shouldCloseOnOverlayClick: PropTypes.bool,
-  /** Boolean indicating if pressing the esc key should close the modal */
+  /** Boolean indicating if pressing the esc key should close the Modal. */
   shouldCloseOnEsc: PropTypes.bool,
-  /** Function that will be called to get the parent element that the modal will be attached to. */
+  /** Function that will be called to get the parent element to which the Modal will be attached. */
   parentSelector: PropTypes.func,
-  /** Styles applied to the overlay div */
+  /** Styles applied to the overlay div. */
   overlayStyle: PropTypes.object,
-  /** Styles applied to the container dialog div */
+  /** Styles applied to the container dialog div. */
   dialogStyle: PropTypes.object
 };
 

--- a/src/Modal/ModalActions.js
+++ b/src/Modal/ModalActions.js
@@ -8,7 +8,7 @@ const ModalActions = ({ children, ...other }) => {
 };
 
 ModalActions.propTypes = {
-  /** The content of teh component */
+  /** The content of the component. */
   children: PropTypes.node
 };
 

--- a/src/Modal/doc/Modal.md
+++ b/src/Modal/doc/Modal.md
@@ -1,6 +1,6 @@
-Modals are meant to "take over" the screen and focus users attention on a dialog which presents the user with an opportunity to add, modify or create content. A modal should always be centered both vertically and horizontally within the browser window. When a modal is opened, the interface darkens and disables all other user interface elements in order to force a user to take an action required by their workflow. Two modals can't be open at once.
+Modals are meant to "take over" the screen and focus users attention on a dialog which presents the user with an opportunity to add, modify or create content. A Modal should always be centered both vertically and horizontally within the browser window. When a Modal is opened, the interface darkens and disables all other user interface elements in order to force a user to take an action required by their workflow. Two Modals can't be open at once.
 
-Note: A modal requires the `appElement` prop to be aria-compliant. Details on how to set this property can be found at http://reactcommunity.org/react-modal/accessibility/
+Note: A Modal requires the `appElement` prop to be aria-compliant. Details on how to set this property can be found at http://reactcommunity.org/react-modal/accessibility/
 
 Example: Create a DOM element dynamically and pass it via `appElement` prop to `Modal`
 

--- a/src/Modal/doc/Modal.mdx
+++ b/src/Modal/doc/Modal.mdx
@@ -13,9 +13,9 @@ import { CalciteH1, CalciteP } from '../../Elements';
 
 # Modal
 
-Modals are meant to "take over" the screen and focus users attention on a dialog which presents the user with an opportunity to add, modify or create content. A modal should always be centered both vertically and horizontally within the browser window. When a modal is opened, the interface darkens and disables all other user interface elements in order to force a user to take an action required by their workflow. Two modals can't be open at once.
+Modals are meant to "take over" the screen and focus users attention on a dialog which presents the user with an opportunity to add, modify or create content. A Modal should always be centered both vertically and horizontally within the browser window. When a Modal is opened, the interface darkens and disables all other user interface elements in order to force a user to take an action required by their workflow. Two Modals can't be open at once.
 
-Note: A modal requires the `appElement` prop to be aria-compliant. Details on how to set this property can be found at http://reactcommunity.org/react-modal/accessibility/
+Note: A Modal requires the `appElement` prop to be aria-compliant. Details on how to set this property can be found at http://reactcommunity.org/react-modal/accessibility/
 
 #### Example: Create a DOM element dynamically and pass it via `appElement` prop to `Modal`
 ```jsx

--- a/src/MultiSelect/MultiSelect.js
+++ b/src/MultiSelect/MultiSelect.js
@@ -313,17 +313,17 @@ const MultiSelect = ({
 };
 
 MultiSelect.propTypes = {
-  /** Nodes to be used as options in the Select */
+  /** Nodes to be used as options in the Select. */
   children: PropTypes.node,
   /** Callback function fired when the value of the Select changes. */
   onChange: PropTypes.func,
-  /** Callback function fired when the Select element is blurred */
+  /** Callback function fired when the Select element is blurred. */
   onBlur: PropTypes.func,
-  /** The selected item of the select */
+  /** The selected item of the Select. */
   selectedItem: PropTypes.node,
-  /** Value of the selected item */
+  /** Value of the selected item. */
   selectedValue: PropTypes.node,
-  /** Placement of the popover in relation to the target */
+  /** Placement of the popover in relation to the target. */
   placement: PropTypes.oneOf([
     'top',
     'right',
@@ -338,23 +338,23 @@ MultiSelect.propTypes = {
     'bottom-end',
     'left-end'
   ]),
-  /** Placeholder text for the input */
+  /** Placeholder text for the input. */
   placeholder: PropTypes.string,
-  /** Whether or not the select will fill its container's width */
+  /** Whether or not the Select will fill its container's width. */
   fullWidth: PropTypes.bool,
-  /** A style variant for select inputs */
+  /** A style variant for Select inputs. */
   minimal: PropTypes.bool,
-  /** Style prop applied to the menu wrapper */
+  /** Style prop applied to the menu wrapper. */
   menuStyle: PropTypes.object,
-  /** Uses `position: fixed` on the tooltip allowing it to show up outside of containers that have `overflow: hidden` */
+  /** Uses `position: fixed` on the tooltip allowing it to show up outside of containers that have `overflow: hidden`. */
   positionFixed: PropTypes.bool,
-  /** Whether or not to close the menu on each selection */
+  /** Whether or not to close the menu on each selection. */
   closeOnSelect: PropTypes.bool,
-  /** Use react-virtualized to render rows as the user scrolls */
+  /** Use react-virtualized to render rows as the user scrolls. */
   virtualized: PropTypes.bool,
-  /** (virtualized only) Row height used to calculate how many rows to render in a virtualized menu */
+  /** (virtualized only) Row height used to calculate how many rows to render in a virtualized Menu. */
   virtualizedRowHeight: PropTypes.oneOfType([PropTypes.number, PropTypes.func]),
-  /** (virtualized only) Width of the menu, unloaded rows may be wider than the initial set */
+  /** (virtualized only) Width of the menu; unloaded rows may be wider than the initial set. */
   virtualizedMenuWidth: PropTypes.number
 };
 

--- a/src/Panel/Panel.js
+++ b/src/Panel/Panel.js
@@ -8,23 +8,23 @@ const Panel = ({ children, ...other }) => {
 };
 
 Panel.propTypes = {
-  /** Content of the Panel */
+  /** Content of the Panel. */
   children: PropTypes.node,
-  /** Hide the border of the panel */
+  /** Hide the border of the Panel. */
   noBorder: PropTypes.bool,
-  /** Remove the padding from the panel */
+  /** Remove the padding from the Panel. */
   noPadding: PropTypes.bool,
-  /** Dark style panel */
+  /** Dark style Panel. */
   dark: PropTypes.bool,
-  /** Black style panel */
+  /** Black style Panel. */
   black: PropTypes.bool,
-  /** White style panel */
+  /** White style Panel. */
   white: PropTypes.bool,
-  /** Light Blue style panel */
+  /** Light Blue style Panel. */
   lightBlue: PropTypes.bool,
-  /** Blue style panel */
+  /** Blue style Panel. */
   blue: PropTypes.bool,
-  /** Dark Blue style panel */
+  /** Dark Blue style Panel. */
   darkBlue: PropTypes.bool
 };
 

--- a/src/Panel/PanelText.js
+++ b/src/Panel/PanelText.js
@@ -8,7 +8,7 @@ const PanelText = ({ children, ...other }) => {
 };
 
 PanelText.propTypes = {
-  /** Content of the PanelText */
+  /** Content of the PanelText. */
   children: PropTypes.node
 };
 

--- a/src/Panel/PanelTitle.js
+++ b/src/Panel/PanelTitle.js
@@ -8,7 +8,7 @@ const PanelTitle = ({ children, ...other }) => {
 };
 
 PanelTitle.propTypes = {
-  /** Content of the PanelTitle */
+  /** Content of the PanelTitle. */
   children: PropTypes.node
 };
 

--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -138,13 +138,13 @@ class Popover extends Component {
 }
 
 Popover.propTypes = {
-  /** Nodes to be used as options in the Popover */
+  /** Nodes to be used as options in the Popover. */
   children: PropTypes.node,
-  /** The element that will anchor the popover */
+  /** The element that will anchor the Popover. */
   targetEl: PropTypes.node,
-  /** Whether the popover is visible or not */
+  /** Whether or not the Popover is visible. */
   open: PropTypes.bool,
-  /** Placement of the popover in relation to the target */
+  /** Placement of the Popover in relation to the target. */
   placement: PropTypes.oneOf([
     'top',
     'right',
@@ -159,19 +159,19 @@ Popover.propTypes = {
     'bottom-end',
     'left-end'
   ]),
-  /** Duration of animation in milliseconds */
+  /** Duration of animation in milliseconds. */
   transitionDuration: PropTypes.number,
-  /** How long it takes for the popover to show up */
+  /** How long it takes for the Popover to show up. */
   enterDelay: PropTypes.number,
-  /** Function called when the popover receives an event that may trigger a close */
+  /** Function called when the Popover receives an event that may trigger a close. */
   onRequestClose: PropTypes.func,
-  /** Whether or not the popover should trigger onRequestClose when an element is selected */
+  /** Whether or not the Popover should trigger onRequestClose when an element is selected. */
   closeOnSelect: PropTypes.bool,
-  /** Styles passed onto the target element container div */
+  /** Styles passed onto the target element container div. */
   targetContainerStyles: PropTypes.object,
-  /** Styles passed onto the popover container div */
+  /** Styles passed onto the Popover container div. */
   popoverContainerStyles: PropTypes.object,
-  /** Uses `position: fixed` on the tooltip allowing it to show up outside of containers that have `overflow: hidden` */
+  /** Uses `position: fixed` on the tooltip allowing it to show up outside of containers that have `overflow: hidden`. */
   positionFixed: PropTypes.bool
 };
 

--- a/src/Radio/Radio.js
+++ b/src/Radio/Radio.js
@@ -93,15 +93,15 @@ const Radio = ({
 };
 
 Radio.propTypes = {
-  /** The text label for the Radio */
+  /** The text label for the Radio. */
   children: PropTypes.node,
-  /** The form value for this checkbox */
+  /** The form value for this Radio button. */
   value: PropTypes.string,
-  /** The name to be shared among checkboxes in a group */
+  /** The name to be shared among Radio buttons in a group. */
   name: PropTypes.string,
-  /** Whether the checkbox is currently checked */
+  /** Whether the Radio button is currently checked. */
   checked: PropTypes.bool,
-  /** Event called when the checkbox value should be toggled */
+  /** Event called when the Radio button value should be toggled. */
   onChange: PropTypes.func
 };
 

--- a/src/Search/Search.js
+++ b/src/Search/Search.js
@@ -402,23 +402,23 @@ class Search extends Component {
 }
 
 Search.propTypes = {
-  /** Array of items */
+  /** Array of items. */
   items: PropTypes.array,
-  /** Text in the input */
+  /** Text in the input. */
   inputValue: PropTypes.string,
-  /** The selected item */
+  /** The selected item. */
   selectedItem: PropTypes.any,
-  /** Text for the placeholder property on the input */
+  /** Text for the placeholder property on the input. */
   placeholder: PropTypes.string,
-  /** An object used to map properties to name and value of items (only applies if `items` is an array of objects) */
+  /** An object used to map properties to the name and value of items (only applies if `items` is an array of objects). */
   dataSourceConfig: PropTypes.object,
-  /** Function called when an item is selected */
+  /** Function called when an item is selected. */
   onChange: PropTypes.func,
-  /** Function called when the input value is changed, items dropdown hides/shows, hovers an item, or clicks on an item */
+  /** Function called when the input value is changed, items dropdown hides/shows, or when the user hovers over or clicks on an item. */
   onUserAction: PropTypes.func,
-  /** Function called when the user clicks the clear button */
+  /** Function called when the user clicks the clear button. */
   onRequestClear: PropTypes.func,
-  /** Placement of the popover in relation to the target */
+  /** Placement of the popover in relation to the target. */
   placement: PropTypes.oneOf([
     'top',
     'right',
@@ -433,27 +433,27 @@ Search.propTypes = {
     'bottom-end',
     'left-end'
   ]),
-  /** Toggle minimal style on the input */
+  /** Toggle minimal style on the input. */
   minimal: PropTypes.bool,
-  /** Whether or not the search and its menu will fill the container's width */
+  /** Whether or not the Search and its menu will fill the container's width. */
   fullWidth: PropTypes.bool,
-  /** Style prop applied to the Search container element */
+  /** Style prop applied to the Search container element. */
   containerStyle: PropTypes.object,
-  /** Style prop applied to the menu wrapper */
+  /** Style prop applied to the menu wrapper. */
   menuStyle: PropTypes.object,
-  /** Character used to display a shortcut icon on the right side of the search input */
+  /** Character used to display a shortcut icon on the right side of the Search input. */
   shortcutCharacter: PropTypes.string,
-  /** Text used in the shortcut tooltip to describe what the shortcut is */
+  /** Text used in the shortcut tooltip to describe what the shortcut is. */
   shortcutTooltip: PropTypes.node,
-  /** Uses `position: fixed` on the tooltip allowing it to show up outside of containers that have `overflow: hidden` */
+  /** Uses `position: fixed` on the tooltip allowing it to show up outside of containers that have `overflow: hidden`. */
   positionFixed: PropTypes.bool,
-  /** You can add search options as children if you want more control over the item rendering. Search MenuItems can take either an item object that maps to your dataSourceConfig or you can manually set the label and value props on MenuItems */
+  /** You can add Search options as children if you want more control over the item rendering. Search MenuItems can take either an item object that maps to your dataSourceConfig, or you can manually set the label and value props on MenuItems. */
   children: PropTypes.node,
-  /** Use react-virtualized to render rows as the user scrolls */
+  /** Use react-virtualized to render rows as the user scrolls. */
   virtualized: PropTypes.bool,
-  /** (virtualized only) Row height used to calculate how many rows to render in a virtualized menu */
+  /** (virtualized only) Row height used to calculate how many rows to render in a virtualized menu. */
   virtualizedRowHeight: PropTypes.oneOfType([PropTypes.number, PropTypes.func]),
-  /** (virtualized only) Width of the menu, unloaded rows may be wider than the initial set */
+  /** (virtualized only) Width of the menu; unloaded rows may be wider than the initial set. */
   virtualizedMenuWidth: PropTypes.number
 };
 

--- a/src/Select/Select.js
+++ b/src/Select/Select.js
@@ -435,31 +435,31 @@ class Select extends Component {
 }
 
 Select.propTypes = {
-  /** Nodes to be used as options in the Select */
+  /** Nodes to be used as options in the Select. */
   children: PropTypes.node,
-  /** Toggle the select to use an input and allow filtering of the items */
+  /** Toggle the Select to use an input and allow filtering of the items. */
   filterable: PropTypes.bool,
-  /** Use react-virtualized to render rows as the user scrolls */
+  /** Use react-virtualized to render rows as the user scrolls. */
   virtualized: PropTypes.bool,
   /** Callback function fired when the value of the Select changes. */
   onChange: PropTypes.func,
-  /** The selected item of the select */
+  /** The selected item of the Select. */
   selectedItem: PropTypes.node,
-  /** Value of the selected item */
+  /** Value of the selected item. */
   selectedValue: PropTypes.node,
-  /** Placeholder text for the input */
+  /** Placeholder text for the input. */
   placeholder: PropTypes.string,
-  /** Whether or not the select will fill its container's width */
+  /** Whether or not the Select will fill its container's width. */
   fullWidth: PropTypes.bool,
-  /** A style variant for select inputs */
+  /** A style variant for Select inputs. */
   minimal: PropTypes.bool,
-  /** HTML prop for the Select, works together with a label's `for` prop */
+  /** HTML prop for the Select; works together with a label's `for` prop. */
   id: PropTypes.string,
-  /** Style prop applied to the menu wrapper */
+  /** Style prop applied to the menu wrapper. */
   menuStyle: PropTypes.object,
-  /** Uses `position: fixed` on the tooltip allowing it to show up outside of containers that have `overflow: hidden` */
+  /** Uses `position: fixed` on the tooltip, allowing it to show up outside of containers that have `overflow: hidden`. */
   positionFixed: PropTypes.bool,
-  /** Specify where the menu should appear in relation to the Select element */
+  /** Specify where the menu should appear in relation to the Select element. */
   placement: PropTypes.oneOf([
     'auto',
     'top',
@@ -475,9 +475,9 @@ Select.propTypes = {
     'left-start',
     'left-end'
   ]),
-  /** (virtualized only) Row height used to calculate how many rows to render in a virtualized menu */
+  /** (virtualized only) Row height used to calculate how many rows to render in a virtualized menu. */
   virtualizedRowHeight: PropTypes.oneOfType([PropTypes.number, PropTypes.func]),
-  /** (virtualized only) Width of the menu, unloaded rows may be wider than the initial set */
+  /** (virtualized only) Width of the menu; unloaded rows may be wider than the initial set. */
   virtualizedMenuWidth: PropTypes.number
 };
 

--- a/src/SideNav/SideNav.js
+++ b/src/SideNav/SideNav.js
@@ -8,7 +8,7 @@ const SideNav = ({ children, ...other }) => {
 };
 
 SideNav.propTypes = {
-  /** The content of the component */
+  /** The content of the component. */
   children: PropTypes.node
 };
 

--- a/src/SideNav/SideNavLink.js
+++ b/src/SideNav/SideNavLink.js
@@ -8,7 +8,7 @@ const SideNavLink = ({ children, ...other }) => {
 };
 
 SideNavLink.propTypes = {
-  /** The content of the component */
+  /** The content of the component. */
   children: PropTypes.node
 };
 

--- a/src/SideNav/SideNavTitle.js
+++ b/src/SideNav/SideNavTitle.js
@@ -8,7 +8,7 @@ const SideNavTitle = ({ children, ...other }) => {
 };
 
 SideNavTitle.propTypes = {
-  /** The content of the component */
+  /** The content of the component. */
   children: PropTypes.node
 };
 

--- a/src/Slider/Slider.js
+++ b/src/Slider/Slider.js
@@ -60,13 +60,13 @@ const Slider = ({
 };
 
 Slider.propTypes = {
-  /** Numeric value of the current value of the Slider */
+  /** Numeric value of the current value of the Slider. */
   value: PropTypes.number,
-  /** Minimum allowable value */
+  /** Minimum allowable value. */
   min: PropTypes.number,
-  /** Maximum allowable value */
+  /** Maximum allowable value. */
   max: PropTypes.number,
-  /** Size of the steps on the Slider */
+  /** Size of the steps on the Slider. */
   step: PropTypes.number
 };
 

--- a/src/Stepper/Step.js
+++ b/src/Stepper/Step.js
@@ -61,9 +61,9 @@ const Step = ({
 };
 
 Step.propTypes = {
-  /** The content of the component, can be StepTitle and StepDescription */
+  /** The content of the component; can be StepTitle or StepDescription. */
   children: PropTypes.node,
-  /** A style prop used to render the step in an error state with red text and X icon */
+  /** A style prop used to render the Step in an error state with red text and X icon. */
   error: PropTypes.bool
 };
 

--- a/src/Stepper/StepDescription.js
+++ b/src/Stepper/StepDescription.js
@@ -8,7 +8,7 @@ const StepDescription = ({ children, ...other }) => {
 };
 
 StepDescription.propTypes = {
-  /** The text content of the component */
+  /** The text content of the component. */
   children: PropTypes.node
 };
 

--- a/src/Stepper/StepIcon.js
+++ b/src/Stepper/StepIcon.js
@@ -90,7 +90,7 @@ const StepIcon = ({
 };
 
 StepIcon.propTypes = {
-  /** The content of the component */
+  /** The content of the component. */
   children: PropTypes.node
 };
 

--- a/src/Stepper/StepTitle.js
+++ b/src/Stepper/StepTitle.js
@@ -8,7 +8,7 @@ const StepTitle = ({ children, ...other }) => {
 };
 
 StepTitle.propTypes = {
-  /** The text content of the component */
+  /** The text content of the component. */
   children: PropTypes.node
 };
 

--- a/src/Stepper/Stepper.js
+++ b/src/Stepper/Stepper.js
@@ -33,11 +33,11 @@ const Stepper = ({ children, currentStep, small, vertical, ...other }) => {
 };
 
 Stepper.propTypes = {
-  /** The content of the component, can be a Step */
+  /** The content of the component; can be a Step. */
   children: PropTypes.node,
-  /** A style prop used to render small Steps */
+  /** A style prop used to render small Steps. */
   small: PropTypes.bool,
-  /** A style prop to position the steps vertically */
+  /** A style prop to position the Steps vertically. */
   vertical: PropTypes.bool
 };
 

--- a/src/SubNav/SubNav.js
+++ b/src/SubNav/SubNav.js
@@ -42,17 +42,17 @@ const SubNav = ({ children, blue, ...other }) => {
 };
 
 SubNav.propTypes = {
-  /** The content of the component */
+  /** The content of the component. */
   children: PropTypes.node,
-  /** A style prop to render the SubNav with a blue background */
+  /** A style prop to render the SubNav with a blue background. */
   blue: PropTypes.bool,
-  /** The background image src */
+  /** The background image src. */
   backgroundImage: PropTypes.node,
-  /** If true, the gradient is applied on top of the image */
+  /** If true, the gradient is applied on top of the image. */
   overlayGradient: PropTypes.bool,
-  /** The gradient overlay color to start from the left of the SubNav */
+  /** The gradient overlay color to start from the left of the SubNav. */
   gradientFromColor: PropTypes.string,
-  /** The gradient overlay color to end on the right of the SubNav */
+  /** The gradient overlay color to end on the right of the SubNav. */
   gradientToColor: PropTypes.string
 };
 

--- a/src/SubNav/SubNavActions.js
+++ b/src/SubNav/SubNavActions.js
@@ -8,7 +8,7 @@ const SubNavActions = ({ children, ...other }) => {
 };
 
 SubNavActions.propTypes = {
-  /** The content of the component */
+  /** The content of the component. */
   children: PropTypes.node
 };
 

--- a/src/SubNav/SubNavLink.js
+++ b/src/SubNav/SubNavLink.js
@@ -12,9 +12,9 @@ const SubNavLink = ({ children, active, ...other }) => {
 };
 
 SubNavLink.propTypes = {
-  /** The text content of the component */
+  /** The text content of the component. */
   children: PropTypes.node,
-  /** A style prop to represent a NavLink as active or selected */
+  /** A style prop to represent a NavLink as active or selected. */
   active: PropTypes.bool
 };
 

--- a/src/SubNav/SubNavList.js
+++ b/src/SubNav/SubNavList.js
@@ -8,7 +8,7 @@ const SubNavList = ({ children, ...other }) => {
 };
 
 SubNavList.propTypes = {
-  /** The content of the component, should be SubNavLinks */
+  /** The content of the component; should be SubNavLinks. */
   children: PropTypes.node
 };
 

--- a/src/SubNav/SubNavTitle.js
+++ b/src/SubNav/SubNavTitle.js
@@ -18,7 +18,7 @@ const SubNavTitle = ({ children, ...other }) => {
 };
 
 SubNavTitle.propTypes = {
-  /** The text content of the component */
+  /** The text content of the component. */
   children: PropTypes.node
 };
 

--- a/src/Switch/Switch.js
+++ b/src/Switch/Switch.js
@@ -91,17 +91,17 @@ const Switch = ({
 };
 
 Switch.propTypes = {
-  /** The text label of the Switch */
+  /** The text label of the Switch. */
   children: PropTypes.node,
-  /** The name to be shared among checkboxes in a group */
+  /** The name to be shared among Switches in a group. */
   name: PropTypes.string,
-  /** Whether the checkbox is currently checked */
+  /** Whether the Switch is currently checked. */
   checked: PropTypes.bool,
-  /** Event called when the checkbox value should be toggled */
+  /** Event called when the Switch value should be toggled. */
   onChange: PropTypes.func,
-  /** Should use a red highlight color */
+  /** Should use a red highlight color. */
   destructive: PropTypes.bool,
-  /** Position of the label text in relation to the input */
+  /** Position of the label text in relation to the input. */
   labelPosition: PropTypes.oneOf(['before', 'after'])
 };
 

--- a/src/Table/Table.js
+++ b/src/Table/Table.js
@@ -53,21 +53,21 @@ const Table = ({
 };
 
 Table.propTypes = {
-  /** The content of the component */
+  /** The content of the component. */
   children: PropTypes.node,
-  /** A style prop to render a blue Table */
+  /** A style prop to render a blue Table. */
   blue: PropTypes.bool,
-  /** A style prop to render a Table with striped rows */
+  /** A style prop to render a Table with striped rows. */
   striped: PropTypes.bool,
-  /** A style prop to render Table with no borders or background color */
+  /** A style prop to render Table with no borders or background color. */
   plain: PropTypes.bool,
-  /** A style prop to render Table with no styling */
+  /** A style prop to render Table with no styling. */
   noTable: PropTypes.bool,
-  /** A style prop to remove leading and trailing padding on a Table */
+  /** A style prop to remove leading and trailing padding on a Table. */
   justified: PropTypes.bool,
-  /** A style prop to render a Table with no column borders */
+  /** A style prop to render a Table with no column borders. */
   noCol: PropTypes.bool,
-  /** A style prop to render a Table with no row borders */
+  /** A style prop to render a Table with no row borders. */
   noRow: PropTypes.bool
 };
 

--- a/src/Table/TableBody.js
+++ b/src/Table/TableBody.js
@@ -18,11 +18,11 @@ const TableBody = ({ children, ...other }) => {
 };
 
 TableBody.propTypes = {
-  /** The content of the component */
+  /** The content of the component. */
   children: PropTypes.node,
-  /** A style prop to render a TableBody with no column borders */
+  /** A style prop to render a TableBody with no column borders. */
   noCol: PropTypes.bool,
-  /** A style prop to render a TableBody with no row borders */
+  /** A style prop to render a TableBody with no row borders. */
   noRow: PropTypes.bool
 };
 

--- a/src/Table/TableCell.js
+++ b/src/Table/TableCell.js
@@ -18,7 +18,7 @@ const TableCell = ({ children, ...other }) => {
 };
 
 TableCell.propTypes = {
-  /** The content of the component */
+  /** The content of the component. */
   children: PropTypes.node
 };
 

--- a/src/Table/TableHeader.js
+++ b/src/Table/TableHeader.js
@@ -25,11 +25,11 @@ const TableHeader = ({ children, ...other }) => {
 };
 
 TableHeader.propTypes = {
-  /** The content of the component */
+  /** The content of the component. */
   children: PropTypes.node,
-  /** A style prop to render a Table with no column borders */
+  /** A style prop to render a Table with no column borders. */
   noCol: PropTypes.bool,
-  /** A style prop to render a Table with no row borders */
+  /** A style prop to render a Table with no row borders. */
   noRow: PropTypes.bool
 };
 

--- a/src/Table/TableHeaderCell.js
+++ b/src/Table/TableHeaderCell.js
@@ -26,7 +26,7 @@ const TableHeaderCell = ({ children, ...other }) => {
 };
 
 TableHeaderCell.propTypes = {
-  /** The content of the component */
+  /** The content of the component. */
   children: PropTypes.node
 };
 

--- a/src/Table/TableHeaderRow.js
+++ b/src/Table/TableHeaderRow.js
@@ -23,15 +23,15 @@ const TableHeaderRow = ({ children, ...other }) => {
 };
 
 TableHeaderRow.propTypes = {
-  /** The content of the component */
+  /** The content of the component. */
   children: PropTypes.node,
-  /** A style prop to render a blue Table */
+  /** A style prop to render a blue Table. */
   blue: PropTypes.bool,
-  /** A style prop to render Table with no borders or background color */
+  /** A style prop to render Table with no borders or background color. */
   plain: PropTypes.bool,
-  /** A style prop to render a Table with no column borders */
+  /** A style prop to render a Table with no column borders. */
   noCol: PropTypes.bool,
-  /** A style prop to render a Table with no row borders */
+  /** A style prop to render a Table with no row borders. */
   noRow: PropTypes.bool
 };
 

--- a/src/Table/TableRow.js
+++ b/src/Table/TableRow.js
@@ -26,19 +26,19 @@ const TableRow = ({ children, ...other }) => {
 };
 
 TableRow.propTypes = {
-  /** The content of the component */
+  /** The content of the component. */
   children: PropTypes.node,
-  /** A style prop to render a blue Table */
+  /** A style prop to render a blue Table. */
   blue: PropTypes.bool,
-  /** A style prop to render a Table with striped rows */
+  /** A style prop to render a Table with striped rows. */
   striped: PropTypes.bool,
-  /** A style prop to render Table with no borders or background color */
+  /** A style prop to render Table with no borders or background color. */
   plain: PropTypes.bool,
-  /** A style prop to render Table with no styling */
+  /** A style prop to render Table with no styling. */
   noTable: PropTypes.bool,
-  /** A style prop to render a Table with no column borders */
+  /** A style prop to render a Table with no column borders. */
   noCol: PropTypes.bool,
-  /** A style prop to render a Table with no row borders */
+  /** A style prop to render a Table with no row borders. */
   noRow: PropTypes.bool
 };
 

--- a/src/Tabs/TabContents.js
+++ b/src/Tabs/TabContents.js
@@ -48,7 +48,7 @@ const TabContents = ({
 };
 
 TabContents.propTypes = {
-  /** The content of the component, should be a number of TabSections */
+  /** The content of the component; should be a number of TabSections. */
   children: PropTypes.node
 };
 

--- a/src/Tabs/TabNav.js
+++ b/src/Tabs/TabNav.js
@@ -46,7 +46,7 @@ const TabNav = ({
 };
 
 TabNav.propTypes = {
-  /** The content of the component, should be a number of TabTitles */
+  /** The content of the component; should be a number of TabTitles. */
   children: PropTypes.node
 };
 

--- a/src/Tabs/TabSection.js
+++ b/src/Tabs/TabSection.js
@@ -8,7 +8,7 @@ const TabSection = ({ children, ...other }) => {
 };
 
 TabSection.propTypes = {
-  /** The content of the component */
+  /** The content of the component. */
   children: PropTypes.node
 };
 

--- a/src/Tabs/TabTitle.js
+++ b/src/Tabs/TabTitle.js
@@ -26,7 +26,7 @@ const TabTitle = ({
 };
 
 TabTitle.propTypes = {
-  /** The text content of the component */
+  /** The text content of the component. */
   children: PropTypes.node
 };
 

--- a/src/Tabs/Tabs.js
+++ b/src/Tabs/Tabs.js
@@ -54,19 +54,19 @@ const Tabs = ({
 };
 
 Tabs.propTypes = {
-  /** The content of the component, should be TabNav and TabContents */
+  /** The content of the component; should be TabNav and TabContents. */
   children: PropTypes.node,
-  /** The index of the tab that should be selected and visible */
+  /** The index of the Tab that should be selected and visible. */
   activeTabIndex: PropTypes.number,
-  /** Function callback when a TabTitle is clicked */
+  /** Function callback when a TabTitle is clicked. */
   onTabChange: PropTypes.func,
-  /** Style prop to render a gray Tab */
+  /** Style prop to render a gray Tab. */
   gray: PropTypes.bool,
-  /** Style prop to render a transparent Tab */
+  /** Style prop to render a transparent Tab. */
   transparent: PropTypes.bool,
-  /** Style prop to render a translucent Tab */
+  /** Style prop to render a translucent Tab. */
   translucent: PropTypes.bool,
-  /** Style prop to render a dark Tab */
+  /** Style prop to render a dark Tab. */
   dark: PropTypes.bool
 };
 

--- a/src/Tabs/doc/Tabs.md
+++ b/src/Tabs/doc/Tabs.md
@@ -1,1 +1,1 @@
-The Tab component consists of clickable tabs, that are aligned side by side. The `<TabNav/>` should describe the Tab navigation items and  `<TabContents/>` should describe the sections within. Any Dom-node can be passed as children to the tab section.
+The Tab component consists of clickable tabs that are aligned side by side. The `<TabNav/>` should describe the Tab navigation items and  `<TabContents/>` should describe the sections within. Any Dom-node can be passed as children to the tab section.

--- a/src/Tabs/doc/Tabs.mdx
+++ b/src/Tabs/doc/Tabs.mdx
@@ -10,7 +10,7 @@ import Tabs, { TabNav, TabTitle, TabContents, TabSection } from '../';
 
 # Tabs
 
-The Tabs component consists of clickable tabs, that are aligned side by side. The
+The Tabs component consists of clickable tabs that are aligned side by side. The
 `<TabNav/>` should describe the Tab navigation items and `<TabContents/>`
 should describe the sections within. Any DOM node can be passed as children to
 the tab section.

--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -177,7 +177,7 @@ const TextField = forwardRef(
 );
 
 TextField.propTypes = {
-  /** HTML prop to be applied to the input */
+  /** HTML prop to be applied to the input. */
   type: PropTypes.oneOf([
     'color',
     'email',
@@ -190,23 +190,23 @@ TextField.propTypes = {
     'url',
     'textarea'
   ]),
-  /** HTML prop for the current value of the input */
+  /** HTML prop for the current value of the input. */
   value: PropTypes.node,
-  /** The form control should show an error */
+  /** The form control should show an error. */
   error: PropTypes.bool,
-  /** The form control should show success */
+  /** The form control should show success. */
   success: PropTypes.bool,
-  /** Option to display a magnifying glass icon and clear button to the input */
+  /** Option to display a magnifying glass icon and clear button to the input. */
   search: PropTypes.bool,
-  /** Make the TextField 100% width */
+  /** Make the TextField 100% width. */
   fullWidth: PropTypes.bool,
-  /** Display prop to style the TextField with a simplified UI */
+  /** Display prop to style the TextField with a simplified UI. */
   minimal: PropTypes.bool,
-  /** TextField and label should appear side by side instead of stacked */
+  /** TextField and label should appear side by side instead of stacked. */
   horizontal: PropTypes.bool,
-  /** HTML prop for the TextField, works together with a label's `for` prop */
+  /** HTML prop for the TextField; works together with a label's `for` prop. */
   id: PropTypes.string,
-  /** HTML prop to name the form element */
+  /** HTML prop to name the form element. */
   name: PropTypes.string
 };
 

--- a/src/TextField/doc/TextField.md
+++ b/src/TextField/doc/TextField.md
@@ -1,5 +1,5 @@
 Labels for form elements should describe what the field is. Labels should not be followed by a semicolon. Placeholder text should describe the specifics about formatting or examples for the input text. Placeholder text is optional, and should never be used to replace a label.
 
-Required form fields should be have the required attribute. While optional form fields should be clearly marked with "(optional)".
+Required form fields should have the required attribute. Optional form fields should be clearly marked with "(optional)".
 
 Try not to include too many optional fields, as it will make the form harder to comprehend and complete for the user.

--- a/src/TextField/doc/TextField.mdx
+++ b/src/TextField/doc/TextField.mdx
@@ -27,7 +27,7 @@ followed by a semicolon. Placeholder text should describe the specifics about
 formatting or examples for the input text. Placeholder text is optional, and
 should never be used to replace a label.
 
-Required form fields should be have the required attribute. While optional form
+Required form fields should have the required attribute. Optional form
 fields should be clearly marked with "(optional)".
 
 Try not to include too many optional fields, as it will make the form harder to

--- a/src/Toaster/ToastContainer.js
+++ b/src/Toaster/ToastContainer.js
@@ -31,7 +31,7 @@ const ToastContainer = ({ ...other }) => {
 };
 
 ToastContainer.propTypes = {
-  /* Toggle default visibility of the progress bar in a Toaster */
+  /* Toggle default visibility of the progress bar in a Toaster. */
   showProgress: PropTypes.bool
 };
 

--- a/src/Toaster/Toaster.js
+++ b/src/Toaster/Toaster.js
@@ -44,9 +44,9 @@ class Toaster extends Component {
 Toaster.propTypes = {
   /** Components to be rendered within the Toaster. */
   children: PropTypes.node,
-  /** Type of toaster to render, affects the background color */
+  /** Type of Toaster to render; affects the background color. */
   type: PropTypes.oneOf(['default', 'success', 'info', 'warning', 'error']),
-  /** Position where the toaster will be placed on the screen */
+  /** Position where the Toaster will be placed on the screen. */
   position: PropTypes.oneOf([
     'top-left',
     'top-center',
@@ -55,9 +55,9 @@ Toaster.propTypes = {
     'bottom-center',
     'bottom-left'
   ]),
-  /** How long the toaster should be open for, false if it shouldn't auto close, or a duration in ms for how long it should take to close */
+  /** How long the Toaster should be open for; false if it shouldn't auto close, or a duration in millisecnds for how long it should take to close. */
   autoClose: PropTypes.oneOfType([PropTypes.bool, PropTypes.number]),
-  /** Toggle default visibility of the progress bar in a Toaster */
+  /** Toggle default visibility of the progress bar in a Toaster. */
   showProgress: PropTypes.bool
 };
 

--- a/src/Toaster/doc/Toaster.mdx
+++ b/src/Toaster/doc/Toaster.mdx
@@ -21,7 +21,7 @@ Calcite React `Toaster` extends the react-toastify library. View the
 
 The `Toaster` requires a supporting component called `ToastContainer` to render properly. 
 Only one `ToastContainer` is allowed per project and it must be higher in the component
-tree than any of the `Toaster`'s you're using.
+tree than any of the `Toaster`s you're using.
 ```jsx
 import React from 'react';
 import ReactDOM from 'react-dom';

--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -105,22 +105,22 @@ class Tooltip extends Component {
 }
 
 Tooltip.propTypes = {
-  /** Nodes to be used as the target of the tooltip */
+  /** Nodes to be used as the target of the Tooltip. */
   children: PropTypes.node,
-  /** Nodes to be used as tooltip content */
+  /** Nodes to be used as Tooltip content. */
   title: PropTypes.node,
-  /** Placement of the popover in relation to the target. The tooltip will override the placement if there is no room.
-   If this property is not set the tooltip will position itself wherever there is room */
+  /** Placement of the popover in relation to the target. The Tooltip will override the placement if there is no room.
+   If this property is not set, the Tooltip will position itself wherever there is room. */
   placement: PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
-  /** Uses `position: fixed` on the tooltip allowing it to show up outside of containers that have `overflow: hidden` */
+  /** Uses `position: fixed` on the Tooltip, allowing it to show up outside of containers that have `overflow: hidden`. */
   positionFixed: PropTypes.bool,
-  /** Duration of animation in milliseconds */
+  /** Duration of animation in milliseconds. */
   transitionDuration: PropTypes.number,
-  /** Delay before the tooltip will show up, in milliseconds */
+  /** Delay (in milliseconds) before the Tooltip will show. */
   enterDelay: PropTypes.number,
-  /** Apply styles to the tooltip element */
+  /** Apply styles to the Tooltip element. */
   style: PropTypes.object,
-  /** Apply styles to the tooltip arrow element */
+  /** Apply styles to the Tooltip arrow element. */
   arrowStyle: PropTypes.object
 };
 

--- a/src/TopNav/TopNav.js
+++ b/src/TopNav/TopNav.js
@@ -8,7 +8,7 @@ const TopNav = ({ children, ...other }) => {
 };
 
 TopNav.propTypes = {
-  /** The content of the component */
+  /** The content of the component. */
   children: PropTypes.node
 };
 

--- a/src/TopNav/TopNavActionsList.js
+++ b/src/TopNav/TopNavActionsList.js
@@ -8,7 +8,7 @@ const TopNavActionsList = ({ children, ...other }) => {
 };
 
 TopNavActionsList.propTypes = {
-  /** The content of the component */
+  /** The content of the component. */
   children: PropTypes.node
 };
 

--- a/src/TopNav/TopNavBrand.js
+++ b/src/TopNav/TopNavBrand.js
@@ -12,11 +12,11 @@ const TopNavBrand = ({ children, src, alt, imageStyle, ...other }) => {
 };
 
 TopNavBrand.propTypes = {
-  /** The html src property of the brand image */
+  /** The HTML src property of the brand image. */
   src: PropTypes.node,
-  /** The html alt property of the brand image */
+  /** The HTML alt property of the brand image. */
   alt: PropTypes.node,
-  /** Style property for the underlying img element */
+  /** Style property for the underlying img element. */
   imageStyle: PropTypes.object
 };
 

--- a/src/TopNav/TopNavLink.js
+++ b/src/TopNav/TopNavLink.js
@@ -12,9 +12,9 @@ const TopNavLink = ({ children, href, ...other }) => {
 };
 
 TopNavLink.propTypes = {
-  /** The content of the component */
+  /** The content of the component. */
   children: PropTypes.node,
-  /** The html href property of the link, if this property is missing the component will render as a span */
+  /** The HTML href property of the link. If this property is missing, the component will render as a span. */
   href: PropTypes.string
 };
 

--- a/src/TopNav/TopNavList.js
+++ b/src/TopNav/TopNavList.js
@@ -7,7 +7,7 @@ const TopNavList = ({ children, ...other }) => {
 };
 
 TopNavList.propTypes = {
-  /** The content of the component */
+  /** The content of the component. */
   children: PropTypes.node
 };
 

--- a/src/TopNav/TopNavTitle.js
+++ b/src/TopNav/TopNavTitle.js
@@ -8,9 +8,9 @@ const TopNavTitle = ({ children, ...other }) => {
 };
 
 TopNavTitle.propTypes = {
-  /** The content of the component */
+  /** The content of the component. */
   children: PropTypes.node,
-  /** The html href property of the TopNavTitle */
+  /** The HTML href property of the TopNavTitle. */
   href: PropTypes.string
 };
 


### PR DESCRIPTION
Majority of edits include capitalizing component referred to in props description or adding periods to the end of the description.

Radio and Switches were referred to as "checkboxes" in their props description. I changed these to radio buttons or switches.

If I found a capitalization style or "," vs ";" style, I went through to make it consistently used throughout the docs (or at least I tried :P).

Impressive work!