### PR TITLE
0.31.2

### DIFF
--- a/src/CalciteThemeProvider/CalciteThemeProvider.js
+++ b/src/CalciteThemeProvider/CalciteThemeProvider.js
@@ -101,6 +101,7 @@ const CalciteReactGlobalStyles = createGlobalStyle`
   .SingleDatePicker_picker,
   .DateRangePicker_picker {
     margin-top: -20px;
+    z-index: 101 !important;
 
     .DayPickerKeyboardShortcuts_buttonReset {
       font-size: 0.875rem;


### PR DESCRIPTION
* `DatePicker` updated to use the same `z-index` as the `Modal` so it will display properly when opened from inside a `Modal`