### PR TITLE
Add icon prop to several components

### DIFF
--- a/src/ComboButton/ComboButton.js
+++ b/src/ComboButton/ComboButton.js
@@ -48,6 +48,7 @@ class ComboButton extends Component {
       label,
       icon,
       iconPosition,
+      dropdownIcon,
       ...other
     } = this.props;
 
@@ -79,7 +80,7 @@ class ComboButton extends Component {
           targetContainerStyles={{ display: 'block' }}
           targetEl={
             <StyledComboButtonDropdown onClick={this.togglePopover} {...other}>
-              <CaretDownIcon filled size={14} />
+              {dropdownIcon}
             </StyledComboButtonDropdown>
           }
         >
@@ -124,12 +125,15 @@ ComboButton.propTypes = {
   /** The icon that will be displayed as the content of a ComboButton. */
   icon: PropTypes.node,
   /** The position of the icon in relation to other children in a ComboButton. */
-  iconPosition: PropTypes.oneOf(['after', 'before'])
+  iconPosition: PropTypes.oneOf(['after', 'before']),
+  /** The icon used inside the dropdown button */
+  dropdownIcon: PropTypes.node
 };
 
 ComboButton.defaultProps = {
   type: 'button',
   iconPosition: 'after',
+  dropdownIcon: <CaretDownIcon filled size={14} />,
   onClick: () => {}
 };
 

--- a/src/ComboButton/doc/ComboButton.mdx
+++ b/src/ComboButton/doc/ComboButton.mdx
@@ -9,6 +9,8 @@ import GuideExample from '../../../docz/GuideExample';
 import Menu, { MenuItem } from '../../Menu';
 import ComboButton from '../';
 
+import ChevronDownIcon from 'calcite-ui-icons-react/ChevronDownIcon';
+
 # ComboButton
 
 A ComboButton has a button on the left and a dropdown containing a menu of more
@@ -116,6 +118,24 @@ import ComboButton from 'calcite-react/ComboButton'
       </Menu>
     </ComboButton>
   </GuideExample>
+</Playground>
+
+## Custom Dropdown icon
+
+<Playground>
+  <ComboButton
+    onClick={() => console.log('primary clicked')}
+    label="Export All"
+    dropdownIcon={<ChevronDownIcon filled size={14} />}
+  >
+    <Menu>
+      <MenuItem onClick={() => console.log('pdf clicked')}>Export PDF</MenuItem>
+      <MenuItem onClick={() => console.log('csv clicked')}>Export CSV</MenuItem>
+      <MenuItem onClick={() => console.log('excel clicked')}>
+        Export Excel
+      </MenuItem>
+    </Menu>
+  </ComboButton>
 </Playground>
 
 ## Props

--- a/src/CopyToClipboard/CopyToClipboard-styled.js
+++ b/src/CopyToClipboard/CopyToClipboard-styled.js
@@ -43,15 +43,10 @@ const StyledCopyToClipboardInput = styled(CalciteInput)`
 const StyledCopyButton = styled(Button)`
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
+
+  svg {
+    margin-left: 0 !important;
+  }
 `;
 
-const ClipboardIconStyles = {
-  marginLeft: 0
-};
-
-export {
-  StyledCopyToClipboard,
-  StyledCopyToClipboardInput,
-  ClipboardIconStyles,
-  StyledCopyButton
-};
+export { StyledCopyToClipboard, StyledCopyToClipboardInput, StyledCopyButton };

--- a/src/CopyToClipboard/CopyToClipboard.js
+++ b/src/CopyToClipboard/CopyToClipboard.js
@@ -15,7 +15,6 @@ import PropTypes from 'prop-types';
 import {
   StyledCopyToClipboard,
   StyledCopyToClipboardInput,
-  ClipboardIconStyles,
   StyledCopyButton
 } from './CopyToClipboard-styled';
 
@@ -70,10 +69,10 @@ class CopyToClipboard extends Component {
 
   getClipboardIcon = () => {
     if (this.state.copySuccessful) {
-      return <CheckIcon style={ClipboardIconStyles} />;
+      return this.props.copySuccessIcon;
     }
 
-    return <CopyToClipboardIcon style={ClipboardIconStyles} />;
+    return this.props.copyIcon;
   };
 
   resetCopySuccess = () => {
@@ -124,13 +123,19 @@ CopyToClipboard.propTypes = {
   /** The tooltip will use appendToBody for positioning on the dom */
   appendToBody: PropTypes.bool,
   /** Style definition passed to the tooltip popover */
-  tooltipStyle: PropTypes.object
+  tooltipStyle: PropTypes.object,
+  /** Icon to be used in the copy to clipboard button */
+  copyIcon: PropTypes.node,
+  /** Icon to be used once the copy to clipboard button has been clicked */
+  copySuccessIcon: PropTypes.node
 };
 
 CopyToClipboard.defaultProps = {
   tooltip: 'Copy',
   successTooltip: 'Copied!',
-  appendToBody: true
+  appendToBody: true,
+  copyIcon: <CopyToClipboardIcon />,
+  copySuccessIcon: <CheckIcon />
 };
 
 CopyToClipboard.displayName = 'CopyToClipboard';

--- a/src/Search/Search-styled.js
+++ b/src/Search/Search-styled.js
@@ -14,7 +14,6 @@ import { CalciteInput } from '../utils/commonElements';
 import { fontSize, unitCalc, transition } from '../utils/helpers';
 
 import XCircleIcon from 'calcite-ui-icons-react/XCircleIcon';
-import MagnifyingGlassIcon from 'calcite-ui-icons-react/MagnifyingGlassIcon';
 
 const StyledCloseCircleIcon = styled(XCircleIcon)`
   display: none;
@@ -29,13 +28,14 @@ const StyledCloseCircleIcon = styled(XCircleIcon)`
   }
 `;
 
-const StyledMagnifyIcon = styled(MagnifyingGlassIcon)`
+const StyledSearchIconContainer = styled.span`
   position: absolute;
-  bottom: 0.65em;
+  bottom: 0.55em;
   left: 0.5em;
   color: ${props => props.theme.palette.darkerGray};
   z-index: 1;
   pointer-events: none;
+  line-height: 0;
 `;
 
 const StyledShortcutCharacter = styled.div`
@@ -63,11 +63,11 @@ const StyledSearchContainer = styled.div`
       width: 100%;
     `};
 
-  ${StyledMagnifyIcon} {
+  ${StyledSearchIconContainer} {
     ${props =>
       props.minimal &&
       css`
-        bottom: 0.75em;
+        bottom: 0.7em;
         left: 0.1rem;
       `};
   }
@@ -101,9 +101,14 @@ const StyledSearchInputWrapper = styled.div`
 `;
 
 const StyledSearch = styled(CalciteInput)`
-  padding-left: ${props => unitCalc(props.theme.baseline, 1.2, '*')};
   padding-right: ${props => props.theme.baseline};
   background: transparent;
+
+  ${props =>
+    props.searchIcon &&
+    css`
+      padding-left: ${props => unitCalc(props.theme.baseline, 1.2, '*')};
+    `};
 
   ${props =>
     props.minimal &&
@@ -147,7 +152,7 @@ export {
   StyledSearch,
   StyledShortcutCharacter,
   StyledCloseCircleIcon,
-  StyledMagnifyIcon,
+  StyledSearchIconContainer,
   ManagerStyle,
   PopperStyle
 };

--- a/src/Search/Search.js
+++ b/src/Search/Search.js
@@ -24,7 +24,7 @@ import {
   StyledSearch,
   StyledShortcutCharacter,
   StyledCloseCircleIcon,
-  StyledMagnifyIcon,
+  StyledSearchIconContainer,
   ManagerStyle,
   PopperStyle
 } from './Search-styled';
@@ -33,6 +33,8 @@ import { StyledSelectMenu } from '../Select/Select-styled';
 import { MenuItem } from '../Menu';
 import Tooltip from '../Tooltip';
 import { ListContext } from '../List/List';
+
+import MagnifyingGlassIcon from 'calcite-ui-icons-react/MagnifyingGlassIcon';
 
 class Search extends Component {
   constructor(props) {
@@ -160,6 +162,16 @@ class Search extends Component {
     });
 
     this.props.onUserAction(inputValue, selectedItemVal);
+  };
+
+  getSearchIcon = searchIcon => {
+    if (searchIcon) {
+      return (
+        <StyledSearchIconContainer>{searchIcon}</StyledSearchIconContainer>
+      );
+    }
+
+    return null;
   };
 
   getClearSearchIcon = () => {
@@ -306,6 +318,7 @@ class Search extends Component {
       virtualized,
       virtualizedRowHeight,
       virtualizedMenuWidth,
+      searchIcon,
       ...other
     } = this.props;
 
@@ -323,7 +336,7 @@ class Search extends Component {
             fullWidth={fullWidth}
             minimal={minimal}
           >
-            <StyledMagnifyIcon filled size={16} />
+            {this.getSearchIcon(searchIcon)}
             <Manager style={ManagerStyle}>
               <Downshift
                 itemToString={this.itemToString}
@@ -353,6 +366,7 @@ class Search extends Component {
                             fullWidth,
                             ref,
                             selectableListFilter: listContext.selectable,
+                            searchIcon,
                             ...other
                           })}
                         />
@@ -471,7 +485,9 @@ Search.propTypes = {
   /** (virtualized only) Row height used to calculate how many rows to render in a virtualized menu. */
   virtualizedRowHeight: PropTypes.oneOfType([PropTypes.number, PropTypes.func]),
   /** (virtualized only) Width of the menu; unloaded rows may be wider than the initial set. */
-  virtualizedMenuWidth: PropTypes.number
+  virtualizedMenuWidth: PropTypes.number,
+  /** SVG icon to be displayed inside the Search input */
+  searchIcon: PropTypes.node
 };
 
 Search.defaultProps = {
@@ -483,6 +499,7 @@ Search.defaultProps = {
   placement: 'bottom-start',
   shortcutTooltip: 'Press  /  to search',
   virtualizedRowHeight: 42,
+  searchIcon: <MagnifyingGlassIcon filled size={16} />,
   onUserAction: () => {},
   onChange: () => {},
   onRequestClear: () => {}

--- a/src/Search/doc/Search.mdx
+++ b/src/Search/doc/Search.mdx
@@ -10,6 +10,7 @@ import { MenuItem } from '../../Menu';
 import { ListItem, ListItemTitle, ListItemSubtitle } from '../../List';
 
 import GlobeIcon from 'calcite-ui-icons-react/GlobeIcon';
+import FileMagnifyingGlassIcon from 'calcite-ui-icons-react/FileMagnifyingGlassIcon';
 
 import statesJson from '../../../docz/_sampleJson/states.json';
 import statesJson2 from '../../../docz/_sampleJson/states_objects.json';
@@ -170,6 +171,17 @@ import Search from 'calcite-react/Search'
       return <SearchStory />;
     }}
 
+</Playground>
+
+## Replace Search Icon
+
+<Playground>
+  <GuideExample label="searchIcon={<FileMagnifyingGlassIcon size={16} />}">
+    <Search searchIcon={<FileMagnifyingGlassIcon size={16} />} />
+  </GuideExample>
+  <GuideExample label="searchIcon={false}">
+    <Search searchIcon={false} />
+  </GuideExample>
 </Playground>
 
 ## Array of Objects


### PR DESCRIPTION
* Add the ability to change or remove the icon from several components. Should allow you to use whatever icon library that fits your brand.
* `Search` - `searchIcon`
* `ComboButton` - `dropdownIcon`
* `CopyToClipboard` - `copyIcon` & `copySuccessIcon`