### PR TITLE
Disable prop for various list controls

### DIFF
--- a/src/List/List-styled.js
+++ b/src/List/List-styled.js
@@ -77,6 +77,13 @@ const StyledListItem = styled.div`
   cursor: pointer;
 
   ${props =>
+    props.disabled &&
+    css`
+      pointer-events: none;
+      opacity: 0.7;
+    `};
+
+  ${props =>
     props.active &&
     css`
       ${props => getActiveStyles(props)};

--- a/src/List/ListItem.js
+++ b/src/List/ListItem.js
@@ -89,7 +89,9 @@ ListItem.propTypes = {
   /** Toggle the active style of a ListItem */
   active: PropTypes.bool,
   /** Add some styles to display a Search element properly inside a ListItem  */
-  filterItem: PropTypes.bool
+  filterItem: PropTypes.bool,
+  /** Toggle the disabled state of the ListItem, results in the item being unselectable and slightly lower opacity */
+  disabled: PropTypes.bool
 };
 
 ListItem.defaultProps = {};

--- a/src/Menu/Menu-styled.js
+++ b/src/Menu/Menu-styled.js
@@ -42,6 +42,13 @@ const StyledMenuItem = styled(CalciteA)`
   cursor: pointer;
 
   ${props =>
+    props.disabled &&
+    css`
+      pointer-events: none;
+      opacity: 0.7;
+    `};
+
+  ${props =>
     props.active &&
     css`
       background-color: ${props => props.theme.palette.offWhite};

--- a/src/Menu/MenuItem.js
+++ b/src/Menu/MenuItem.js
@@ -32,7 +32,9 @@ MenuItem.propTypes = {
   /** Content of the MenuItem. */
   children: PropTypes.node,
   /** A container for content to be displayed right aligned in the MenuItem. */
-  subtitle: PropTypes.node
+  subtitle: PropTypes.node,
+  /** Toggle the disabled state of the MenuItem, results in the item being unselectable and slightly lower opacity */
+  disabled: PropTypes.bool
 };
 
 MenuItem.defaultProps = {};

--- a/src/Menu/doc/Menu.mdx
+++ b/src/Menu/doc/Menu.mdx
@@ -38,7 +38,7 @@ import Menu, {
     <MenuItem>Option 3</MenuItem>
     <MenuTitle>More Options</MenuTitle>
     <MenuItem>Option 4</MenuItem>
-    <MenuItem>Option 5</MenuItem>
+    <MenuItem disabled>Option 5 Disabled</MenuItem>
   </Menu>
 </Playground>
 

--- a/src/SideNav/SideNav-styled.js
+++ b/src/SideNav/SideNav-styled.js
@@ -51,6 +51,13 @@ const StyledSideNavLink = styled(CalciteA)`
   }
 
   ${props =>
+    props.disabled &&
+    css`
+      pointer-events: none;
+      opacity: 0.7;
+    `};
+
+  ${props =>
     props.active &&
     css`
       text-indent: -3px;

--- a/src/SideNav/SideNavLink.js
+++ b/src/SideNav/SideNavLink.js
@@ -20,7 +20,9 @@ const SideNavLink = ({ children, ...other }) => {
 
 SideNavLink.propTypes = {
   /** The content of the component. */
-  children: PropTypes.node
+  children: PropTypes.node,
+  /** Toggle the disabled state of the SideNavLink, results in the item being unselectable and slightly lower opacity */
+  disabled: PropTypes.bool
 };
 
 SideNavLink.defaultProps = {};


### PR DESCRIPTION
* Add `disabled` prop to `MenuItem`, `ListItem`, and `SideNavLink`
* Disabled items are un-selectable and have 70% opacity