### PR TITLE
0.34.0

### DIFF
--- a/src/Breadcrumbs/Breadcrumbs-styled.js
+++ b/src/Breadcrumbs/Breadcrumbs-styled.js
@@ -23,7 +23,7 @@ const StyledCrumb = styled(CalciteA)`
   color: ${props => props.theme.palette.darkerGray};
 
   &::before {
-    content: '/';
+    content: '${props => props.dividerCharacter}';
     color: ${props => props.theme.palette.darkerGray};
     font-weight: 400;
     display: inline-block;
@@ -54,7 +54,7 @@ const StyledSpanCrumb = styled.span`
   color: ${props => props.theme.palette.darkerGray};
 
   &::before {
-    content: '/';
+    content: '${props => props.dividerCharacter}';
     color: ${props => props.theme.palette.darkerGray};
     font-weight: 400;
     display: inline-block;

--- a/src/Breadcrumbs/Breadcrumbs.js
+++ b/src/Breadcrumbs/Breadcrumbs.js
@@ -15,13 +15,15 @@ import { StyledBreadcrumbs } from './Breadcrumbs-styled';
 
 const BreadcrumbsContext = createContext({
   breadcrumbsContext: {
-    white: undefined
+    white: undefined,
+    dividerCharacter: undefined
   }
 });
 
-const Breadcrumbs = ({ children, white, ...other }) => {
+const Breadcrumbs = ({ children, white, dividerCharacter, ...other }) => {
   const breadcrumbsContext = {
-    white
+    white,
+    dividerCharacter
   };
 
   return (
@@ -35,10 +37,14 @@ Breadcrumbs.propTypes = {
   /** Crumb components to be rendered within Breadcrumbs. */
   children: PropTypes.node,
   /** Color modifier for the Breadcrumbs. */
-  white: PropTypes.bool
+  white: PropTypes.bool,
+  /** The character used as a divider between Crumbs */
+  dividerCharacter: PropTypes.node
 };
 
-Breadcrumbs.defaultProps = {};
+Breadcrumbs.defaultProps = {
+  dividerCharacter: '/'
+};
 
 Breadcrumbs.displayName = 'Breadcrumbs';
 

--- a/src/Breadcrumbs/Crumb.js
+++ b/src/Breadcrumbs/Crumb.js
@@ -38,7 +38,9 @@ Crumb.propTypes = {
   /** Boolean to toggle the light style for Breadcrumbs. */
   white: PropTypes.bool,
   /** href html prop */
-  href: PropTypes.string
+  href: PropTypes.string,
+  /** The character used as a divider between Crumbs; by default it will inherit the parent Breadcrumbs dividerCharacter */
+  dividerCharacter: PropTypes.node
 };
 
 Crumb.defaultProps = {};

--- a/src/Breadcrumbs/doc/Breadcrumbs.mdx
+++ b/src/Breadcrumbs/doc/Breadcrumbs.mdx
@@ -44,6 +44,20 @@ import Breadcrumbs, { Crumb } from 'calcite-react/Breadcrumbs'
   </GuideExample>
 </Playground>
 
+## Custom Divider Character
+
+<Playground>
+  <GuideExample label={`dividerCharacter="»"`}>
+    <Breadcrumbs dividerCharacter="»">
+      <Crumb href="#">Thing</Crumb>
+      <Crumb>Thing</Crumb>
+      <Crumb href="#">Thing</Crumb>
+      <Crumb href="#">Current</Crumb>
+    </Breadcrumbs>
+  </GuideExample>
+</Playground>
+
+
 ## Props
 
 ### Breadcrumbs `default`


### PR DESCRIPTION
- Implement a `dividerCharacter` prop on `Breadcrumbs` to allow the user to specify what text character is used to separate `Crumb` elements.