### PR TITLE
0.36.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1944,16 +1944,6 @@
         "normalize-path": "^2.1.1"
       }
     },
-    "aphrodite": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/aphrodite/-/aphrodite-2.2.3.tgz",
-      "integrity": "sha512-e09soRmp1MGzGibAzSOBMnIqq7zF9DwYM2d4jurnf9CKDGnJqQizGkUtwCIyodZv9tj2eIyGskeKA7RhUbXQrA==",
-      "requires": {
-        "asap": "^2.0.3",
-        "inline-style-prefixer": "^4.0.2",
-        "string-hash": "^1.1.3"
-      }
-    },
     "app-root-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-2.1.0.tgz",
@@ -3000,11 +2990,6 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true
-    },
-    "bowser": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.9.4.tgz",
-      "integrity": "sha512-9IdMmj2KjigRq6oWhmwv1W36pDuA4STQZ8q6YO9um+x07xgYNCD3Oou+WP/3L1HNz7iqythGet3/p4wvc8AAwQ=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -4437,15 +4422,6 @@
       "requires": {
         "postcss": "^7.0.1",
         "timsort": "^0.3.0"
-      }
-    },
-    "css-in-js-utils": {
-      "version": "2.0.1",
-      "resolved": "http://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz",
-      "integrity": "sha512-PJF0SpJT+WdbVVt0AOYp9C8GnuruRlL/UFW7932nLWmFLQTaWEzTBQEx7/hn4BuV+WON75iAViSUJLiU3PKbpA==",
-      "requires": {
-        "hyphenate-style-name": "^1.0.2",
-        "isobject": "^3.0.1"
       }
     },
     "css-loader": {
@@ -11473,11 +11449,6 @@
         }
       }
     },
-    "hyphenate-style-name": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz",
-      "integrity": "sha1-MRYKNpMK2vH8BMYHT360FGXU7Es="
-    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -11700,15 +11671,6 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
-    },
-    "inline-style-prefixer": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-4.0.2.tgz",
-      "integrity": "sha512-N8nVhwfYga9MiV9jWlwfdj1UDIaZlBFu4cJSJkIr7tZX7sHpHhGR5su1qdpW+7KPL8ISTvCIkcaFi/JdBknvPg==",
-      "requires": {
-        "bowser": "^1.7.3",
-        "css-in-js-utils": "^2.0.0"
-      }
     },
     "internal-ip": {
       "version": "4.2.0",
@@ -12245,7 +12207,8 @@
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "dev": true
     },
     "isomorphic-fetch": {
       "version": "2.2.1",
@@ -16926,9 +16889,9 @@
       }
     },
     "popper.js": {
-      "version": "1.14.6",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.14.6.tgz",
-      "integrity": "sha512-AGwHGQBKumlk/MDfrSOf0JHhJCImdDMcGNoqKmKkU+68GFazv3CQ6q9r7Ja1sKDZmYWTckY/uLyEznheTDycnA=="
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.15.0.tgz",
+      "integrity": "sha512-w010cY1oCUmI+9KwwlWki+r5jxKfTFDVoadl7MSrIujHU5MJ5OR6HTDj6Xo8aoR/QsA56x8jKjA59qGH4ELtrA=="
     },
     "portfinder": {
       "version": "1.0.20",
@@ -18290,9 +18253,9 @@
       }
     },
     "react-popper": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.2.tgz",
-      "integrity": "sha512-UbFWj55Yt9uqvy0oZ+vULDL2Bw1oxeZF9/JzGyxQ5ypgauRH/XlarA5+HLZWro/Zss6Ht2kqpegtb6sYL8GUGw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.3.tgz",
+      "integrity": "sha512-ynMZBPkXONPc5K4P5yFWgZx5JGAUIP3pGGLNs58cfAPgK67olx7fmLp+AdpZ0+GoQ+ieFDa/z4cdV6u7sioH6w==",
       "requires": {
         "@babel/runtime": "^7.1.2",
         "create-react-context": "<=0.2.2",
@@ -18303,9 +18266,9 @@
       },
       "dependencies": {
         "warning": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.2.tgz",
-          "integrity": "sha512-wbTp09q/9C+jJn4KKJfJfoS6VleK/Dti0yqWSm6KMvJ4MRCXFQNapHuJXutJIrWV0Cf4AhTdeIe4qdKHR1+Hug==",
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+          "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
           "requires": {
             "loose-envify": "^1.0.0"
           }
@@ -18484,18 +18447,6 @@
         "hoist-non-react-statics": "^2.5.0",
         "prop-types": "^15.6.1",
         "react-with-direction": "^1.3.0"
-      }
-    },
-    "react-with-styles-interface-aphrodite": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/react-with-styles-interface-aphrodite/-/react-with-styles-interface-aphrodite-5.0.1.tgz",
-      "integrity": "sha512-heDh8B8GkmyFeIey8xFNMq8oUEzi8yu+E1OhXX04SO6r5nq4KUDxtUSY4uU/ZzKTACRe/51LaqXaxaExhe6t7g==",
-      "requires": {
-        "array.prototype.flat": "^1.2.1",
-        "has": "^1.0.3",
-        "object.assign": "^4.1.0",
-        "object.entries": "^1.0.4",
-        "rtl-css-js": "^1.10.0"
       }
     },
     "react-with-styles-interface-css": {
@@ -19162,14 +19113,6 @@
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
       "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
       "dev": true
-    },
-    "rtl-css-js": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/rtl-css-js/-/rtl-css-js-1.11.0.tgz",
-      "integrity": "sha512-YnZ6jWxZxlWlcQAGF9vOmiF9bEmoQmSHE+wsrsiILkdK9HqiRPAIll4SY/QDzbvEu2lB2h62+hfg3TYzjnldbA==",
-      "requires": {
-        "@babel/runtime": "^7.1.2"
-      }
     },
     "run-async": {
       "version": "2.3.0",
@@ -20355,11 +20298,6 @@
       "requires": {
         "any-observable": "^0.2.0"
       }
-    },
-    "string-hash": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
-      "integrity": "sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs="
     },
     "string-length": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     ]
   },
   "dependencies": {
-    "aphrodite": "^2.2.3",
     "calcite-ui-icons-react": "^0.5.0",
     "downshift": "^3.1.1",
     "match-sorter": "^2.3.0",
@@ -70,11 +69,10 @@
     "polished": "^2.3.0",
     "react-dates": "^18.3.1",
     "react-modal": "^3.5.1",
-    "react-popper": "^1.0.2",
+    "react-popper": "^1.3.3",
     "react-toastify": "^4.3.0",
     "react-transition-group": "^2.4.0",
     "react-virtualized": "^9.20.1",
-    "react-with-styles-interface-aphrodite": "^5.0.1",
     "styled-components": "^4.1.2",
     "uniqid": "^5.0.3"
   },

--- a/src/ArcgisAccount/ArcgisAccount.js
+++ b/src/ArcgisAccount/ArcgisAccount.js
@@ -96,6 +96,8 @@ class ArcgisAccount extends Component {
       onRequestSignOut,
       children,
       hideSwitchAccount,
+      switchAccountLabel,
+      signOutLabel,
       ...other
     } = this.props;
 
@@ -126,6 +128,8 @@ class ArcgisAccount extends Component {
           portal={portal}
           avatar={this._getAvatar(user, token, portal, 120)}
           style={{ width: '410px' }}
+          switchAccountLabel={switchAccountLabel}
+          signOutLabel={signOutLabel}
           hideSwitchAccount={hideSwitchAccount}
           onRequestSwitchAccount={onRequestSwitchAccount}
           onRequestSignOut={onRequestSignOut}
@@ -144,6 +148,10 @@ ArcgisAccount.propTypes = {
   portal: PropTypes.object.isRequired,
   /** AGOL login token. */
   token: PropTypes.string,
+  /** Text label for the Switch Account button. */
+  switchAccountLabel: PropTypes.string,
+  /** Text label for the Sign Out button. */
+  signOutLabel: PropTypes.string,
   /** Hide the button to switch accounts in the menu. */
   hideSwitchAccount: PropTypes.bool,
   /** Callback when the user selects the Switch Account button. */
@@ -153,6 +161,8 @@ ArcgisAccount.propTypes = {
 };
 
 ArcgisAccount.defaultProps = {
+  switchAccountLabel: 'Switch Account',
+  signOutLabel: 'Sign Out',
   onRequestSwitchAccount: () => {},
   onRequestSignOut: () => {}
 };

--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -11,7 +11,6 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import uniqid from 'uniqid';
 import moment from 'moment';
 
 import 'react-dates/lib/css/_datepicker.css';

--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -35,8 +35,11 @@ class Popover extends Component {
     this._generatedId = uniqid();
   }
 
-  componentDidUpdate(prevProps, prevState) {
-    if (prevProps.open === false && this.props.open === true) {
+  componentDidUpdate(prevProps) {
+    if (
+      (prevProps.open === false && this.props.open === true) ||
+      (this.props.open === true && prevProps.children !== this.props.children)
+    ) {
       this._setOutsideTap();
     }
 


### PR DESCRIPTION
* Fix issue where a popover would collapse when the user selected an option from a dropdown. This was a regression we missed when we updated selects to only render their menu dom node when `open`. Not having access to that dom node was breaking the outside click handler on Popper.
* Fixed props being passed from `ArcgisAccount` to `ArcgisAccountMenu`, previously was not passing `signOutLabel` or `switchAccountLabel`...
* Updated `react-popper` version and removed unused dependencies for `aphrodite` theming lib