### PR TITLE
Controlled Tooltip

### DIFF
--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -50,6 +50,8 @@ class Tooltip extends Component {
   };
 
   render() {
+    const isOpen =
+      this.props.open !== undefined ? this.props.open : this.state.open;
     const usePreventOverflow =
       this.props.appendToBody || this.props.positionFixed ? false : true;
 
@@ -67,9 +69,9 @@ class Tooltip extends Component {
             </StyledTargetWrapper>
           )}
         </Reference>
-        <Transition in={this.state.open} timeout={this.props.enterDelay}>
+        <Transition in={isOpen} timeout={this.props.enterDelay}>
           {state => {
-            return this.state.open
+            return isOpen
               ? this._getPopper(
                   <Popper
                     positionFixed={this.props.positionFixed}
@@ -121,6 +123,8 @@ Tooltip.propTypes = {
   children: PropTypes.node,
   /** Nodes to be used as Tooltip content. */
   title: PropTypes.node,
+  /** Boolean to programatically control the visibility of the Tooltip */
+  open: PropTypes.bool,
   /** Placement of the popover in relation to the target. The Tooltip will override the placement if there is no room.
    If this property is not set, the Tooltip will position itself wherever there is room. */
   placement: PropTypes.oneOf(['top', 'right', 'bottom', 'left']),

--- a/src/Tooltip/doc/Tooltip.mdx
+++ b/src/Tooltip/doc/Tooltip.mdx
@@ -91,6 +91,14 @@ import Tooltip from 'calcite-react/Tooltip'
   </Tooltip>
 </Playground>
 
+## Programatically Open Tooltip
+
+<Playground>
+  <Tooltip open title="I'm always open because I have the 'open' prop" placement="right">
+    <CalciteA>Don't Hover Me</CalciteA>
+  </Tooltip>
+</Playground>
+
 ## Tooltip on Other Components
 
 <Playground>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Enhance Tooltip to provide an `open` prop, allows a controlled Tooltip

## Description
Added an `open` prop to the `Tooltip`. Use this prop if it's not `undefined`, otherwise use the local state like before

## Related Issue
n/a

## Motivation and Context
Need a way to programmatically open a tooltip without user interaction

## How Has This Been Tested?
n/a...

## Screenshots (if appropriate):
![Screen Shot 2019-07-02 at 2 37 25 PM](https://user-images.githubusercontent.com/5149922/60544894-f6db1c80-9cd6-11e9-8db3-fcf3c7095340.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
