### PR TITLE
Extend `CopyToClipboard` to allow for any component as a child

### DIFF
--- a/src/CopyToClipboard/CopyToClipboard.js
+++ b/src/CopyToClipboard/CopyToClipboard.js
@@ -79,31 +79,77 @@ class CopyToClipboard extends Component {
     this.setState({ copySuccessful: false });
   };
 
+  getContent = (
+    isBasic,
+    children,
+    positionFixed,
+    appendToBody,
+    tooltipStyle,
+    tooltipTargetWrapperStyle
+  ) => {
+    if (isBasic) {
+      return (
+        <>
+          <StyledCopyToClipboardInput as="input" value={children} readOnly />
+          <Tooltip
+            positionFixed={positionFixed}
+            appendToBody={appendToBody}
+            title={this.getTooltipText()}
+            style={tooltipStyle}
+            targetWrapperStyle={tooltipTargetWrapperStyle}
+          >
+            <StyledCopyButton
+              clear
+              onClick={() => this.copyTextToClipboard(children)}
+              onBlur={this.resetCopySuccess}
+              icon={this.getClipboardIcon()}
+            />
+          </Tooltip>
+        </>
+      );
+    }
+
+    return (
+      <Tooltip
+        positionFixed={positionFixed}
+        appendToBody={appendToBody}
+        title={this.getTooltipText()}
+        style={tooltipStyle}
+        targetWrapperStyle={tooltipTargetWrapperStyle}
+      >
+        {children}
+      </Tooltip>
+    );
+  };
+
   render() {
     const {
       children,
       positionFixed,
       appendToBody,
       tooltipStyle,
+      tooltipTargetWrapperStyle,
+      copyValue,
       ...other
     } = this.props;
 
+    const isBasic = typeof children !== 'object';
+
     const copyToClipboard = (
-      <StyledCopyToClipboard {...other}>
-        <StyledCopyToClipboardInput as="input" value={children} readOnly />
-        <Tooltip
-          positionFixed={positionFixed}
-          appendToBody={appendToBody}
-          title={this.getTooltipText()}
-          style={tooltipStyle}
-        >
-          <StyledCopyButton
-            clear
-            onClick={() => this.copyTextToClipboard(children)}
-            onBlur={this.resetCopySuccess}
-            icon={this.getClipboardIcon()}
-          />
-        </Tooltip>
+      <StyledCopyToClipboard
+        onClick={
+          isBasic ? undefined : () => this.copyTextToClipboard(copyValue)
+        }
+        {...other}
+      >
+        {this.getContent(
+          isBasic,
+          children,
+          positionFixed,
+          appendToBody,
+          tooltipStyle,
+          tooltipTargetWrapperStyle
+        )}
       </StyledCopyToClipboard>
     );
 
@@ -113,7 +159,11 @@ class CopyToClipboard extends Component {
 
 CopyToClipboard.propTypes = {
   /** Text to be copied. */
-  children: PropTypes.string,
+  children: PropTypes.node,
+  /** If you're using components as children of this component you must
+   * provide a string value to be copied to the clipboard when clicked
+   */
+  copyValue: PropTypes.string,
   /** The tooltip label before the text is copied. */
   tooltip: PropTypes.string,
   /** The tooltip label after the text is copied. */
@@ -124,6 +174,8 @@ CopyToClipboard.propTypes = {
   appendToBody: PropTypes.bool,
   /** Style definition passed to the tooltip popover */
   tooltipStyle: PropTypes.object,
+  /** Style definition passed to the tooltip target wrapper */
+  tooltipTargetWrapperStyle: PropTypes.object,
   /** Icon to be used in the copy to clipboard button */
   copyIcon: PropTypes.node,
   /** Icon to be used once the copy to clipboard button has been clicked */

--- a/src/CopyToClipboard/doc/CopyToClipboard.mdx
+++ b/src/CopyToClipboard/doc/CopyToClipboard.mdx
@@ -8,6 +8,8 @@ import GuideExample from '../../../docz/GuideExample';
 
 import CopyToClipboard from '../';
 
+import Button from '../../Button';
+
 # CopyToClipboard
 
 A component that allows you to easily make snippets of text selectable and add
@@ -24,6 +26,17 @@ import CopyToClipboard from 'calcite-react/CopyToClipboard'
 <Playground>
   <CopyToClipboard>
     1D0830C9A2A0681A9EFBB001E5B9302BDF6DF02FD52C07DD6F88A3FC1B52DA84
+  </CopyToClipboard>
+</Playground>
+
+## Custom Components
+
+<Playground>
+  <CopyToClipboard copyValue="#5a9359">
+    <Button green>Click me to copy the color to clipboard!</Button>
+  </CopyToClipboard>
+  <CopyToClipboard copyValue="#0079c1">
+    <Button>Click me to copy the color to clipboard!</Button>
   </CopyToClipboard>
 </Playground>
 


### PR DESCRIPTION
Extend `CopyToClipboard` to allow for any component as a child

## Description
Extend `CopyToClipboard` to allow for any component as a child. If the children of a `CopyToClipboard` component is anything but a string or a number, clicking anywhere on the component will copy to clipboard.

## Related Issue
NA

## Motivation and Context
Wanted to have a common method to copy content to a clipboard without the need for it to be in a text input

## Screenshots (if appropriate):
NA

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
