### PR TITLE
0.39.0

### DIFF
--- a/src/CopyToClipboard/CopyToClipboard.js
+++ b/src/CopyToClipboard/CopyToClipboard.js
@@ -79,31 +79,77 @@ class CopyToClipboard extends Component {
     this.setState({ copySuccessful: false });
   };
 
+  getContent = (
+    isBasic,
+    children,
+    positionFixed,
+    appendToBody,
+    tooltipStyle,
+    tooltipTargetWrapperStyle
+  ) => {
+    if (isBasic) {
+      return (
+        <>
+          <StyledCopyToClipboardInput as="input" value={children} readOnly />
+          <Tooltip
+            positionFixed={positionFixed}
+            appendToBody={appendToBody}
+            title={this.getTooltipText()}
+            style={tooltipStyle}
+            targetWrapperStyle={tooltipTargetWrapperStyle}
+          >
+            <StyledCopyButton
+              clear
+              onClick={() => this.copyTextToClipboard(children)}
+              onBlur={this.resetCopySuccess}
+              icon={this.getClipboardIcon()}
+            />
+          </Tooltip>
+        </>
+      );
+    }
+
+    return (
+      <Tooltip
+        positionFixed={positionFixed}
+        appendToBody={appendToBody}
+        title={this.getTooltipText()}
+        style={tooltipStyle}
+        targetWrapperStyle={tooltipTargetWrapperStyle}
+      >
+        {children}
+      </Tooltip>
+    );
+  };
+
   render() {
     const {
       children,
       positionFixed,
       appendToBody,
       tooltipStyle,
+      tooltipTargetWrapperStyle,
+      copyValue,
       ...other
     } = this.props;
 
+    const isBasic = typeof children !== 'object';
+
     const copyToClipboard = (
-      <StyledCopyToClipboard {...other}>
-        <StyledCopyToClipboardInput as="input" value={children} readOnly />
-        <Tooltip
-          positionFixed={positionFixed}
-          appendToBody={appendToBody}
-          title={this.getTooltipText()}
-          style={tooltipStyle}
-        >
-          <StyledCopyButton
-            clear
-            onClick={() => this.copyTextToClipboard(children)}
-            onBlur={this.resetCopySuccess}
-            icon={this.getClipboardIcon()}
-          />
-        </Tooltip>
+      <StyledCopyToClipboard
+        onClick={
+          isBasic ? undefined : () => this.copyTextToClipboard(copyValue)
+        }
+        {...other}
+      >
+        {this.getContent(
+          isBasic,
+          children,
+          positionFixed,
+          appendToBody,
+          tooltipStyle,
+          tooltipTargetWrapperStyle
+        )}
       </StyledCopyToClipboard>
     );
 
@@ -113,7 +159,11 @@ class CopyToClipboard extends Component {
 
 CopyToClipboard.propTypes = {
   /** Text to be copied. */
-  children: PropTypes.string,
+  children: PropTypes.node,
+  /** If you're using components as children of this component you must
+   * provide a string value to be copied to the clipboard when clicked
+   */
+  copyValue: PropTypes.string,
   /** The tooltip label before the text is copied. */
   tooltip: PropTypes.string,
   /** The tooltip label after the text is copied. */
@@ -124,6 +174,8 @@ CopyToClipboard.propTypes = {
   appendToBody: PropTypes.bool,
   /** Style definition passed to the tooltip popover */
   tooltipStyle: PropTypes.object,
+  /** Style definition passed to the tooltip target wrapper */
+  tooltipTargetWrapperStyle: PropTypes.object,
   /** Icon to be used in the copy to clipboard button */
   copyIcon: PropTypes.node,
   /** Icon to be used once the copy to clipboard button has been clicked */

--- a/src/CopyToClipboard/doc/CopyToClipboard.mdx
+++ b/src/CopyToClipboard/doc/CopyToClipboard.mdx
@@ -8,6 +8,8 @@ import GuideExample from '../../../docz/GuideExample';
 
 import CopyToClipboard from '../';
 
+import Button from '../../Button';
+
 # CopyToClipboard
 
 A component that allows you to easily make snippets of text selectable and add
@@ -24,6 +26,17 @@ import CopyToClipboard from 'calcite-react/CopyToClipboard'
 <Playground>
   <CopyToClipboard>
     1D0830C9A2A0681A9EFBB001E5B9302BDF6DF02FD52C07DD6F88A3FC1B52DA84
+  </CopyToClipboard>
+</Playground>
+
+## Custom Components
+
+<Playground>
+  <CopyToClipboard copyValue="#5a9359">
+    <Button green>Click me to copy the color to clipboard!</Button>
+  </CopyToClipboard>
+  <CopyToClipboard copyValue="#0079c1">
+    <Button>Click me to copy the color to clipboard!</Button>
   </CopyToClipboard>
 </Playground>
 

--- a/src/MultiSelect/MultiSelect.js
+++ b/src/MultiSelect/MultiSelect.js
@@ -244,10 +244,24 @@ const MultiSelect = ({
           getInputProps,
           getItemProps,
           isOpen,
+          openMenu,
           selectedItem,
-          highlightedIndex
+          highlightedIndex,
+          selectHighlightedItem
         }) => {
           const selectedValues = getValues(selectedItem);
+
+          const onKeyDown = event => {
+            if (!event) return;
+            if (event.key === 'Enter') {
+            } else if (event.key === ' ') {
+              if (highlightedIndex === null) openMenu();
+              else {
+                event.nativeEvent.preventDefault(); // Avoids an extra space after value
+                selectHighlightedItem();
+              }
+            }
+          };
 
           return (
             <StyledMultiSelectWrapper
@@ -268,7 +282,8 @@ const MultiSelect = ({
                         {...getInputProps({
                           id: id || formControlContext._generatedId,
                           fullWidth: fullWidth,
-                          minimal: minimal
+                          minimal: minimal,
+                          onKeyDown
                         })}
                         {...other}
                       >

--- a/src/Select/Select.js
+++ b/src/Select/Select.js
@@ -46,8 +46,23 @@ class Select extends Component {
       field,
       form,
       renderValue,
+      openMenu,
+      highlightedIndex,
+      selectHighlightedItem,
       ...other
     } = params;
+
+    const onKeyDown = event => {
+      if (!event) return;
+      if (event.key === 'Enter') {
+      } else if (event.key === ' ') {
+        if (highlightedIndex === null) openMenu();
+        else {
+          event.nativeEvent.preventDefault(); // Avoids an extra space after value
+          selectHighlightedItem();
+        }
+      }
+    };
 
     if (filterable) {
       return (
@@ -68,6 +83,7 @@ class Select extends Component {
                 fullWidth: fullWidth,
                 minimal: minimal,
                 style: style,
+                onKeyDown,
                 ...other
               })}
               ref={ref}
@@ -81,7 +97,9 @@ class Select extends Component {
         {({ formControlContext }) => (
           <StyledSelectButton
             {...getToggleButtonProps()}
-            {...getInputProps()}
+            {...getInputProps({
+              onKeyDown
+            })}
             as="button"
             fullWidth={fullWidth}
             minimal={minimal}
@@ -359,6 +377,8 @@ class Select extends Component {
             getInputProps,
             getItemProps,
             isOpen,
+            openMenu,
+            selectHighlightedItem,
             selectedItem,
             highlightedIndex,
             inputValue
@@ -391,6 +411,10 @@ class Select extends Component {
                       style,
                       field,
                       form,
+                      isOpen,
+                      openMenu,
+                      highlightedIndex,
+                      selectHighlightedItem,
                       ...other
                     });
                   }}

--- a/src/Select/doc/Select.mdx
+++ b/src/Select/doc/Select.mdx
@@ -29,13 +29,13 @@ Select allows users to choose one option from a prescribed list.
 #### Import Syntax
 
 ```js
-import Select from 'calcite-react/Select'
+import Select from 'calcite-react/Select';
 ```
 
 ## Basic Usage
 
 <Playground style={{ height: '250px' }}>
-  <Select onChange={() => console.log('onChange')}>
+  <Select onChange={value => console.log(value)}>
     <MenuItem value={10}>Ten</MenuItem>
     <MenuItem value={20}>Twenty</MenuItem>
     <MenuItem value={30}>Thirty</MenuItem>
@@ -46,7 +46,7 @@ import Select from 'calcite-react/Select'
 
 <Playground style={{ height: '550px' }}>
   <GuideExample label="fullWidth">
-    <Select fullWidth onChange={() => console.log('onChange')}>
+    <Select fullWidth onChange={value => console.log(value)}>
       <MenuItem value={10}>Ten</MenuItem>
       <MenuItem value={20}>Twenty</MenuItem>
       <MenuItem value={30}>Thirty</MenuItem>
@@ -62,7 +62,7 @@ import Select from 'calcite-react/Select'
   <GuideExample label="FormControlLabel">
     <FormControl>
       <FormControlLabel>Value:</FormControlLabel>
-      <Select onChange={() => console.log('onChange')}>
+      <Select onChange={value => console.log(value)}>
         <MenuItem value={10}>Ten</MenuItem>
         <MenuItem value={20}>Twenty</MenuItem>
         <MenuItem value={30}>Thirty</MenuItem>
@@ -77,7 +77,7 @@ import Select from 'calcite-react/Select'
     </FormControl>
   </GuideExample>
   <GuideExample label="appendToBody">
-    <Select appendToBody onChange={() => console.log('onChange')}>
+    <Select appendToBody onChange={value => console.log(value)}>
       <MenuItem value={10}>Ten</MenuItem>
       <MenuItem value={20}>Twenty</MenuItem>
       <MenuItem value={30}>Thirty</MenuItem>
@@ -93,7 +93,7 @@ import Select from 'calcite-react/Select'
   <GuideExample label="menuStyle={{maxHeight: 'none'}}">
     <Select
       menuStyle={{ maxHeight: 'none' }}
-      onChange={() => console.log('onChange')}
+      onChange={value => console.log(value)}
     >
       <MenuItem value={10}>Ten</MenuItem>
       <MenuItem value={20}>Twenty</MenuItem>
@@ -408,3 +408,11 @@ import Select from 'calcite-react/Select'
 ## Props
 
 <PropsTable of={Select} />
+
+## Notes
+
+For keyboard interaction, Select menus can be opened and selected from using the
+`Spacebar`or the `Enter` keys. The `Enter` key does not trigger form submission
+when a Select is in focus. When using a `filterable` Select, the menu can be
+opened with the `Down Arrow` key. A Select can be closed without altering its
+value with the `Escape` key.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
- Improve Enter/Space behavior on `Select`, `MultiSelect` components
- Extend `CopyToClipboard` component to allow for any component as a child

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- #267 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Modifications to `Select` and `MultiSelect` behavior bring them more in line with standard browser behavior.
By allowing CopyToKeyboard to render any component as a child opens new options such as rendering a color swatch to copy its hex value.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested keyboard behavior via documentation pages.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
