### PR TITLE
ArcGIS Share with everyone selects org

### DIFF
--- a/src/ArcgisShare/ArcgisShare.js
+++ b/src/ArcgisShare/ArcgisShare.js
@@ -147,8 +147,9 @@ class ArcgisShare extends Component {
         <Checkbox
           id="org"
           labelStyle={{ ...PrimaryCheckboxLabelStyles }}
-          checked={this.state.org || false}
+          checked={this.state.org || this.state.public || false}
           onChange={this.orgChange}
+          disabled={this.state.public || false}
         >
           {this.props.portal && this.props.portal.name}
         </Checkbox>


### PR DESCRIPTION
## Description
Automatically select and disable the organization checkbox when "Everyone (public)" is selected

## Related Issue
#275 	

## Motivation and Context
Covers an inconsistency with arcgis online's share behavior

## How Has This Been Tested?
- [x] Tested with a sharing definition that had public selected
- [x] Tested with a sharing definition that had org selected

## Screenshots (if appropriate):
![Screen Shot 2019-07-30 at 11 55 34 AM](https://user-images.githubusercontent.com/5149922/62153034-f7a8a380-b2c0-11e9-9c47-dccb57bddef1.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
