### PR TITLE
#255 - Doc default inherited Modal props

### DIFF
--- a/src/Modal/Modal.js
+++ b/src/Modal/Modal.js
@@ -70,9 +70,9 @@ Modal.propTypes = {
   onAfterOpen: PropTypes.func,
   /** Function that will be run when the Modal is requested to be closed (either by clicking on overlay or pressing ESC). */
   onRequestClose: PropTypes.func,
-  /** Boolean indicating if the overlay should close the Modal. */
+  /** Boolean indicating if clicking the overlay should call the onRequestClose prop. */
   shouldCloseOnOverlayClick: PropTypes.bool,
-  /** Boolean indicating if pressing the esc key should close the Modal. */
+  /** Boolean indicating if pressing the esc key should call the onRequestClose prop. */
   shouldCloseOnEsc: PropTypes.bool,
   /** Function that will be called to get the parent element to which the Modal will be attached. */
   parentSelector: PropTypes.func,

--- a/src/Modal/Modal.js
+++ b/src/Modal/Modal.js
@@ -84,7 +84,9 @@ Modal.propTypes = {
 
 Modal.defaultProps = {
   onAfterOpen: () => {},
-  onRequestClose: () => {}
+  onRequestClose: () => {},
+  shouldCloseOnOverlayClick: true,
+  shouldCloseOnEsc: true
 };
 
 Modal.displayName = 'Modal';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds `shouldCloseOnOverlayClick` and `shouldCloseOnEsc` to `Modal.defaultProps`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#255 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
User confusion over expected behavior.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
N/A

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
