### PR TITLE
Document `as` prop and sample usage

### DIFF
--- a/docz/Customizing_Calcite.mdx
+++ b/docz/Customizing_Calcite.mdx
@@ -64,6 +64,29 @@ const App = () => {
 export default App;
 ```
 
+### `as` Polymorphic Property
+
+If you want to keep all the styling you've applied to a component but just switch
+out what's being ultimately rendered (be it a different HTML tag or a different
+custom component), you can use the
+[`as` prop](https://www.styled-components.com/docs/api#as-polymorphic-prop) to do this
+at runtime.
+
+```jsx
+const Component = styled.div`
+  color: red;
+`;
+
+render(
+  <Component
+    as="button"
+    onClick={() => alert('It works!')}
+  >
+    Hello World!
+  </Component>
+)
+```
+
 ## Customizing the Theme
 
 Limited theming is possible with Calcite React by extending the

--- a/src/TopNav/TopNav-styled.js
+++ b/src/TopNav/TopNav-styled.js
@@ -79,7 +79,7 @@ const StyledTopNavLink = styled(CalciteA)`
       border-bottom-color: ${props.theme.palette.blue};
     `};
 
-  .active,
+  &.active,
   .active > & {
     color: ${props => props.theme.palette.offBlack};
     border-bottom-color: ${props => props.theme.palette.blue};

--- a/src/TopNav/TopNav-styled.js
+++ b/src/TopNav/TopNav-styled.js
@@ -79,6 +79,7 @@ const StyledTopNavLink = styled(CalciteA)`
       border-bottom-color: ${props.theme.palette.blue};
     `};
 
+  .active,
   .active > & {
     color: ${props => props.theme.palette.offBlack};
     border-bottom-color: ${props => props.theme.palette.blue};

--- a/src/TopNav/doc/TopNav.mdx
+++ b/src/TopNav/doc/TopNav.mdx
@@ -56,6 +56,33 @@ import TopNav, {
   </TopNav>
 </Playground>
 
+### With React Router
+
+Using [React Router](https://reacttraining.com/react-router/web/guides/quick-start) with
+Calcite React components is straight-forward. Pass the router component class to the `as`
+prop on whatever component needs the functionality provided by router. Props assigned to
+the Calcite component will be inherited by the underlying router component.
+
+```jsx
+import { NavLink } from 'react-router-dom'
+...
+<TopNav>
+  <TopNavBrand href="#" src={EsriLogo} />
+  <TopNavTitle href="#">ArcGIS for Developers</TopNavTitle>
+  <TopNavList>
+    <TopNavLink as={NavLink} to="/plans">
+      Plans
+    </TopNavLink>
+    <TopNavLink as={NavLink} to="/community">Community</TopNavLink>
+    <TopNavLink as={NavLink} to="/docs">Docs</TopNavLink>
+  </TopNavList>
+  <TopNavActionsList>
+    <TopNavLink href="#">Sign In</TopNavLink>
+    <Button clear>Sign Up</Button>
+  </TopNavActionsList>
+</TopNav>
+```
+
 ## Props
 
 ### TopNav `default`


### PR DESCRIPTION
## Description
Documented `as` prop, show usage with react router in TopNav, update TopNavLink styles to work with `.active` class properly

## Related Issue
#236

## Motivation and Context
`as` is used in several places in the library but not documented anywhere. There was also no documentation of a supported way to use react router. This update should provide guidance on a best practice for using these components together.

## How Has This Been Tested?
Tested in [codesandbox](https://codesandbox.io/s/calcite-react-template-d3dri) 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
