### PR TITLE
Add `theme` to defaultProps for each styled-component

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,3 +25,47 @@ To get started, go ahead and fork this repo. Once you've done that, there are a 
 ## Submitting a Pull Request
 
 Once you're ready to submit your changes, submit a pull request **into the `develop` branch**. Often it's a good idea to open an issue to discuss your proposed changes before making a PR, but you're welcome to submit a PR without an issue - just be sure to include a good description of your changes.
+
+# styled-component file snippet (VSCode)
+
+```
+"Stub out a calcite-react styled-component": {
+  "prefix": "calcite-styled-component",
+  "body": [
+    "// Copyright 2019 Esri",
+    "// Licensed under the Apache License, Version 2.0 (the \"License\");",
+    "// you may not use this file except in compliance with the License.",
+    "// You may obtain a copy of the License at",
+    "// http://www.apache.org/licenses/LICENSE-2.0",
+    "// Unless required by applicable law or agreed to in writing, software",
+    "// distributed under the License is distributed on an \"AS IS\" BASIS,",
+    "// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.",
+    "// See the License for the specific language governing permissions and",
+    "// limitations under the License.​",
+    "",
+    "// styled-components",
+    "import styled, { css } from 'styled-components';",
+    "",
+    "// Utils, common elements",
+    "import { unitCalc, fontSize } from '../utils/helpers';",
+    "",
+    "// Calcite theme and Esri colors",
+    "import { CalciteTheme as theme } from '../CalciteThemeProvider';",
+    "",
+    "// Calcite components",
+    "",
+    "// Icons",
+    "",
+    "// Third party libraries",
+    "",
+    "const $1 = styled()`",
+    "",
+    "`;",
+    "$1.defaultProps = { theme };",
+    "",
+    "export { $1 };",
+    ""
+  ],
+  "description": "Stub out a calcite-react styled-component"
+}
+```

--- a/doczrc.js
+++ b/doczrc.js
@@ -18,7 +18,7 @@ export default {
   public: '/docz/public',
 
   // Wrapper component for each mdx file, used to wrap everything in CalciteThemeProvider
-  wrapper: __dirname + '/docz/ThemeWrapper',
+  wrapper: '../../docz/ThemeWrapper',
 
   // Ordering of the side menu, used here to put "Getting Started" first
   menu: ['Getting Started', 'Customization & Theme', 'Calcite Icons'],

--- a/src/Accordion/Accordion-styled.js
+++ b/src/Accordion/Accordion-styled.js
@@ -14,11 +14,16 @@ import { transition } from '../utils/helpers';
 import { StyledSideNav, StyledSideNavTitle } from '../SideNav/SideNav-styled';
 import ChevronRightIcon from 'calcite-ui-icons-react/ChevronRightIcon';
 
+// Calcite theme
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
 const StyledAccordion = styled(StyledSideNav)`
   border-radius: ${props => props.theme.borderRadius};
 `;
+StyledAccordion.defaultProps = { theme };
 
 const StyledAccordionSection = styled.div``;
+StyledAccordionSection.defaultProps = { theme };
 
 const StyledAccordionTitle = styled(StyledSideNavTitle)`
   display: flex;
@@ -49,6 +54,7 @@ const StyledAccordionTitle = styled(StyledSideNavTitle)`
       pointer-events: none;
     `};
 `;
+StyledAccordionTitle.defaultProps = { theme };
 
 const StyledAccordionContent = styled.div`
   display: none;
@@ -59,6 +65,7 @@ const StyledAccordionContent = styled.div`
       display: block;
     `};
 `;
+StyledAccordionContent.defaultProps = { theme };
 
 const StyledChevronIcon = styled(ChevronRightIcon)`
   width: 20;
@@ -72,6 +79,7 @@ const StyledChevronIcon = styled(ChevronRightIcon)`
       transform: rotate(90deg);
     `};
 `;
+StyledChevronIcon.defaultProps = { theme };
 
 export {
   StyledAccordion,

--- a/src/Accordion/Accordion-styled.js
+++ b/src/Accordion/Accordion-styled.js
@@ -9,13 +9,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.​
 
+// styled-components
 import styled, { css } from 'styled-components';
+
+// Utils, common elements
 import { transition } from '../utils/helpers';
+
+// Calcite theme and Esri colors
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
+// Calcite components
 import { StyledSideNav, StyledSideNavTitle } from '../SideNav/SideNav-styled';
+
+// Icons
 import ChevronRightIcon from 'calcite-ui-icons-react/ChevronRightIcon';
 
-// Calcite theme
-import { CalciteTheme as theme } from '../CalciteThemeProvider';
+// Third party libraries
 
 const StyledAccordion = styled(StyledSideNav)`
   border-radius: ${props => props.theme.borderRadius};

--- a/src/Alert/Alert-styled.js
+++ b/src/Alert/Alert-styled.js
@@ -9,13 +9,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.​
 
+// styled-components
 import styled, { css } from 'styled-components';
+
+// Utils, common elements
 import { unitCalc } from '../utils/helpers';
 import { linkColor } from '../utils/color';
+
+// Calcite theme and Esri colors
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
+// Calcite components
 import { CalciteA } from '../Elements';
 
-// Calcite theme
-import { CalciteTheme as theme } from '../CalciteThemeProvider';
+// Icons
+
+// Third party libraries
 
 const StyledAlert = styled.div`
   padding: ${props => unitCalc(props.theme.baseline, 2, '/')};

--- a/src/Alert/Alert-styled.js
+++ b/src/Alert/Alert-styled.js
@@ -14,6 +14,9 @@ import { unitCalc } from '../utils/helpers';
 import { linkColor } from '../utils/color';
 import { CalciteA } from '../Elements';
 
+// Calcite theme
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
 const StyledAlert = styled.div`
   padding: ${props => unitCalc(props.theme.baseline, 2, '/')};
   color: ${props => props.theme.palette.offBlack};
@@ -55,6 +58,7 @@ const StyledAlert = styled.div`
       max-width: none;
     `};
 `;
+StyledAlert.defaultProps = { theme };
 
 const StyledAlertClose = styled(CalciteA)`
   position: absolute;
@@ -69,5 +73,6 @@ const StyledAlertClose = styled(CalciteA)`
     fill: currentColor;
   }
 `;
+StyledAlertClose.defaultProps = { theme };
 
 export { StyledAlert, StyledAlertClose };

--- a/src/ArcgisAccount/ArcgisAccount-styled.js
+++ b/src/ArcgisAccount/ArcgisAccount-styled.js
@@ -9,12 +9,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.​
 
+// styled-components
 import styled, { css } from 'styled-components';
+
+// Utils, common elements
 import { fontSize, unitCalc } from '../utils/helpers';
+
+// Calcite theme and Esri colors
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
+// Calcite components
 import Button from '../Button';
 
-// Calcite theme
-import { CalciteTheme as theme } from '../CalciteThemeProvider';
+// Icons
+
+// Third party libraries
 
 const StyledArcgisAccountControl = styled.div`
   display: flex;

--- a/src/ArcgisAccount/ArcgisAccount-styled.js
+++ b/src/ArcgisAccount/ArcgisAccount-styled.js
@@ -13,6 +13,9 @@ import styled, { css } from 'styled-components';
 import { fontSize, unitCalc } from '../utils/helpers';
 import Button from '../Button';
 
+// Calcite theme
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
 const StyledArcgisAccountControl = styled.div`
   display: flex;
   align-items: center;
@@ -47,38 +50,45 @@ const StyledArcgisAccountControl = styled.div`
       }
     `};
 `;
+StyledArcgisAccountControl.defaultProps = { theme };
 
 const StyledArcgisAccountControlAvatar = styled.div`
   margin-right: ${props => unitCalc(props.theme.baseline, 2, '/')};
 `;
+StyledArcgisAccountControlAvatar.defaultProps = { theme };
 
 const StyledArcgisAccountControlNames = styled.div`
   flex: 1 0 50px;
   display: flex;
   flex-direction: column;
 `;
+StyledArcgisAccountControlNames.defaultProps = { theme };
 const StyledArcgisAccountControlFriendlyName = styled.span`
   font-weight: 600;
   ${fontSize(-1)};
   line-height: 20px;
 `;
+StyledArcgisAccountControlFriendlyName.defaultProps = { theme };
 const StyledArcgisAccountControlUsername = styled.span`
   font-weight: 300;
   ${fontSize(-2)};
   line-height: 16px;
 `;
+StyledArcgisAccountControlUsername.defaultProps = { theme };
 
 const StyledArcgisAccountMenu = styled.div`
   background: ${props => props.theme.palette.white};
   box-shadow: ${props => props.theme.boxShadow};
   border-radius: ${props => props.theme.borderRadius};
 `;
+StyledArcgisAccountMenu.defaultProps = { theme };
 
 const StyledArcgisAccountContent = styled.div`
   display: flex;
   min-height: 210px;
   padding-top: ${props => unitCalc(props.theme.baseline, 2, '*')};
 `;
+StyledArcgisAccountContent.defaultProps = { theme };
 const StyledArcgisAccountContentInfo = styled.div`
   display: flex;
   flex-direction: column;
@@ -86,17 +96,20 @@ const StyledArcgisAccountContentInfo = styled.div`
   align-items: center;
   flex: 1 0 50px;
 `;
+StyledArcgisAccountContentInfo.defaultProps = { theme };
 const StyledArcgisAccountContentName = styled.span`
   ${fontSize(1)};
   font-weight: 600;
   display: inline-block;
   margin-bottom: ${props => unitCalc(props.theme.baseline, 2, '/')};
 `;
+StyledArcgisAccountContentName.defaultProps = { theme };
 const StyledArcgisAccountContentId = styled.span`
   ${fontSize(-2)};
   font-weight: 300;
   line-height: 20px;
 `;
+StyledArcgisAccountContentId.defaultProps = { theme };
 const StyledArcgisAccountContentGroup = styled.span`
   ${fontSize(-2)};
   font-weight: 300;
@@ -105,6 +118,7 @@ const StyledArcgisAccountContentGroup = styled.span`
   text-align: center;
   padding: 0 ${props => unitCalc(props.theme.baseline, 4, '/')};
 `;
+StyledArcgisAccountContentGroup.defaultProps = { theme };
 
 const StyledArcgisAccountContentMenu = styled.div`
   flex: 1 0 30px;
@@ -114,10 +128,12 @@ const StyledArcgisAccountContentMenu = styled.div`
   flex-direction: column;
   align-items: flex-start;
 `;
+StyledArcgisAccountContentMenu.defaultProps = { theme };
 
 const StyledArcgisAccountSignInMenu = styled.div`
   display: flex;
 `;
+StyledArcgisAccountSignInMenu.defaultProps = { theme };
 
 const StyledArcgisAccountMenuItem = styled.a`
   cursor: pointer;
@@ -152,17 +168,20 @@ const StyledArcgisAccountMenuItem = styled.a`
     }
   }
 `;
+StyledArcgisAccountMenuItem.defaultProps = { theme };
 
 const StyledSwitchAccountButton = styled(Button)`
   flex: 1 0 50px;
   border-radius: 0 0 0 ${props => props.theme.borderRadius};
 `;
+StyledSwitchAccountButton.defaultProps = { theme };
 
 const StyledSignOutButton = styled(Button)`
   flex: 1 0 50px;
   margin-left: 0;
   border-radius: 0 0 ${props => props.theme.borderRadius} 0;
 `;
+StyledSignOutButton.defaultProps = { theme };
 
 export {
   StyledArcgisAccountControl,

--- a/src/ArcgisItemCard/ArcgisItemCard-styled.js
+++ b/src/ArcgisItemCard/ArcgisItemCard-styled.js
@@ -62,6 +62,7 @@ const StyledItemCardImageWrap = styled(StyledCardImageWrap).attrs(props => ({
   justify-content: center;
   border-right: 1px solid ${props => props.theme.palette.lightestGray};
 `;
+StyledItemCardImageWrap.defaultProps = { theme };
 
 const StyledCardItemTitle = styled(StyledCardTitle)`
   ${fontSize(1)};

--- a/src/ArcgisItemCard/ArcgisItemCard-styled.js
+++ b/src/ArcgisItemCard/ArcgisItemCard-styled.js
@@ -20,9 +20,13 @@ import { fontSize, unitCalc } from '../utils/helpers';
 import UserIcon from 'calcite-ui-icons-react/UserIcon';
 import CalendarIcon from 'calcite-ui-icons-react/CalendarIcon';
 
+// Calcite theme
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
 const StyledItemCard = styled(StyledCard)`
   border-radius: ${props => props.theme.borderRadius};
 `;
+StyledItemCard.defaultProps = { theme };
 
 const StyledItemCardContent = styled(StyledCardContent)`
   white-space: normal;
@@ -30,6 +34,7 @@ const StyledItemCardContent = styled(StyledCardContent)`
   padding: ${props => unitCalc(props.theme.baseline, 3, '/')};
   box-sizing: border-box;
 `;
+StyledItemCardContent.defaultProps = { theme };
 
 // Set background image with attributes so that styled components doesn't
 // make a new class for every instance of this element that has a new image
@@ -53,6 +58,7 @@ const StyledCardItemTitle = styled(StyledCardTitle)`
   ${fontSize(1)};
   margin-bottom: ${props => unitCalc(props.theme.baseline, 5, '/')};
 `;
+StyledCardItemTitle.defaultProps = { theme };
 
 const StyledCardItemMetrics = styled.div`
   display: flex;
@@ -63,6 +69,7 @@ const StyledCardItemMetrics = styled.div`
     border-bottom: none;
   }
 `;
+StyledCardItemMetrics.defaultProps = { theme };
 
 const StyledCardItemText = styled.p`
   font-weight: 300;
@@ -70,6 +77,7 @@ const StyledCardItemText = styled.p`
   ${fontSize(-2)};
   margin: ${props => unitCalc(props.theme.baseline, 3, '/')} 0 0;
 `;
+StyledCardItemText.defaultProps = { theme };
 
 const StyledCardItemIconLabelText = styled(StyledCardItemText)`
   display: flex;
@@ -87,14 +95,17 @@ const StyledCardItemIconLabelText = styled(StyledCardItemText)`
     height: 1.4em;
   }
 `;
+StyledCardItemIconLabelText.defaultProps = { theme };
 
 const StyledUserIcon = styled(UserIcon)`
   margin-right: ${props => unitCalc(props.theme.baseline, 6, '/')};
 `;
+StyledUserIcon.defaultProps = { theme };
 
 const StyledCalendarIcon = styled(CalendarIcon)`
   margin-right: ${props => unitCalc(props.theme.baseline, 4, '/')};
 `;
+StyledCalendarIcon.defaultProps = { theme };
 
 export {
   StyledItemCard,

--- a/src/ArcgisItemCard/ArcgisItemCard-styled.js
+++ b/src/ArcgisItemCard/ArcgisItemCard-styled.js
@@ -9,19 +9,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.​
 
+// styled-components
 import styled from 'styled-components';
+
+// Utils, common elements
+import { fontSize, unitCalc } from '../utils/helpers';
+
+// Calcite theme and Esri colors
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
+// Calcite components
 import {
   StyledCard,
   StyledCardTitle,
   StyledCardContent,
   StyledCardImageWrap
 } from '../Card/Card-styled';
-import { fontSize, unitCalc } from '../utils/helpers';
+
+// Icons
 import UserIcon from 'calcite-ui-icons-react/UserIcon';
 import CalendarIcon from 'calcite-ui-icons-react/CalendarIcon';
 
-// Calcite theme
-import { CalciteTheme as theme } from '../CalciteThemeProvider';
+// Third party libraries
 
 const StyledItemCard = styled(StyledCard)`
   border-radius: ${props => props.theme.borderRadius};

--- a/src/ArcgisShare/ArcgisShare-styled.js
+++ b/src/ArcgisShare/ArcgisShare-styled.js
@@ -10,14 +10,17 @@
 // limitations under the License.​
 
 import styled from 'styled-components';
-import { CalciteTheme } from '../CalciteThemeProvider';
 import { unitCalc } from '../utils/helpers';
 import StarIcon from 'calcite-ui-icons-react/StarIcon';
 import { Legend } from '../Form';
 
+// Calcite theme
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
 import { fontSize } from '../utils/helpers';
 
 const StyledArcgisShare = styled.div``;
+StyledArcgisShare.defaultProps = { theme };
 
 const StyledGroupContainer = styled.div`
   position: relative;
@@ -29,10 +32,11 @@ const StyledGroupContainer = styled.div`
   overflow-y: auto;
   border-radius: ${props => props.theme.borderRadius};
 `;
+StyledGroupContainer.defaultProps = { theme };
 
 const PrimaryCheckboxLabelStyles = {
   fontSize: '1rem',
-  color: CalciteTheme.palette.black
+  color: theme.palette.black
 };
 
 const GroupCheckboxLabelStyles = {
@@ -50,10 +54,12 @@ const StyledStarIcon = styled(StarIcon)`
   vertical-align: text-top;
   margin-left: 2px;
 `;
+StyledStarIcon.defaultProps = { theme };
 
 const StyledLegend = styled(Legend)`
   font-size: 1rem;
 `;
+StyledLegend.defaultProps = { theme };
 
 const StyledNoGroups = styled.span`
   position: absolute;
@@ -67,6 +73,7 @@ const StyledNoGroups = styled.span`
   color: ${props => props.theme.palette.lightGray};
   ${fontSize(-2)};
 `;
+StyledNoGroups.defaultProps = { theme };
 
 export {
   StyledArcgisShare,

--- a/src/ArcgisShare/ArcgisShare-styled.js
+++ b/src/ArcgisShare/ArcgisShare-styled.js
@@ -9,15 +9,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.​
 
+// styled-components
 import styled from 'styled-components';
-import { unitCalc } from '../utils/helpers';
-import StarIcon from 'calcite-ui-icons-react/StarIcon';
-import { Legend } from '../Form';
 
-// Calcite theme
+// Utils, common elements
+import { unitCalc, fontSize } from '../utils/helpers';
+
+// Calcite theme and Esri colors
 import { CalciteTheme as theme } from '../CalciteThemeProvider';
 
-import { fontSize } from '../utils/helpers';
+// Calcite components
+import { Legend } from '../Form';
+
+// Icons
+import StarIcon from 'calcite-ui-icons-react/StarIcon';
+
+// Third party libraries
 
 const StyledArcgisShare = styled.div``;
 StyledArcgisShare.defaultProps = { theme };

--- a/src/Avatar/Avatar-styled.js
+++ b/src/Avatar/Avatar-styled.js
@@ -9,10 +9,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.​
 
+// styled-components
 import styled, { css } from 'styled-components';
 
-// Calcite theme
+// Utils, common elements
+
+// Calcite theme and Esri colors
 import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
+// Calcite components
+
+// Icons
+
+// Third party libraries
 
 const StyledAvatar = styled.div`
   width: ${props => props.aSize}px;

--- a/src/Avatar/Avatar-styled.js
+++ b/src/Avatar/Avatar-styled.js
@@ -11,6 +11,9 @@
 
 import styled, { css } from 'styled-components';
 
+// Calcite theme
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
 const StyledAvatar = styled.div`
   width: ${props => props.aSize}px;
   height: ${props => props.aSize}px;
@@ -32,6 +35,7 @@ const StyledAvatar = styled.div`
       font-size: ${props.fontSize}px;
     `};
 `;
+StyledAvatar.defaultProps = { theme };
 
 const StyledAvatarImage = styled.img`
   width: 100%;
@@ -39,6 +43,7 @@ const StyledAvatarImage = styled.img`
   text-align: center;
   object-fit: cover;
 `;
+StyledAvatarImage.defaultProps = { theme };
 
 const StyledAvatarSvg = {
   fill: 'currentColor',
@@ -53,5 +58,6 @@ const StyledAvatarText = styled.span`
   font-weight: 300;
   font-family: ${props => props.theme.type.avenirFamily};
 `;
+StyledAvatarText.defaultProps = { theme };
 
 export { StyledAvatar, StyledAvatarImage, StyledAvatarSvg, StyledAvatarText };

--- a/src/Breadcrumbs/Breadcrumbs-styled.js
+++ b/src/Breadcrumbs/Breadcrumbs-styled.js
@@ -14,10 +14,14 @@ import { linkColor } from '../utils/color';
 import { CalciteA } from '../Elements';
 import { fontSize } from '../utils/helpers';
 
+// Calcite theme
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
 const StyledBreadcrumbs = styled.nav`
   ${fontSize(-2)};
   color: ${props => props.theme.palette.darkerGray};
 `;
+StyledBreadcrumbs.defaultProps = { theme };
 
 const StyledCrumb = styled(CalciteA)`
   color: ${props => props.theme.palette.darkerGray};
@@ -49,6 +53,7 @@ const StyledCrumb = styled(CalciteA)`
       }
     `};
 `;
+StyledCrumb.defaultProps = { theme };
 
 const StyledSpanCrumb = styled.span`
   color: ${props => props.theme.palette.darkerGray};
@@ -80,5 +85,6 @@ const StyledSpanCrumb = styled.span`
       }
     `};
 `;
+StyledSpanCrumb.defaultProps = { theme };
 
 export { StyledBreadcrumbs, StyledCrumb, StyledSpanCrumb };

--- a/src/Breadcrumbs/Breadcrumbs-styled.js
+++ b/src/Breadcrumbs/Breadcrumbs-styled.js
@@ -9,13 +9,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.​
 
+// styled-components
 import styled, { css } from 'styled-components';
-import { linkColor } from '../utils/color';
-import { CalciteA } from '../Elements';
-import { fontSize } from '../utils/helpers';
 
-// Calcite theme
+// Utils, common elements
+import { fontSize } from '../utils/helpers';
+import { linkColor } from '../utils/color';
+
+// Calcite theme and Esri colors
 import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
+// Calcite components
+import { CalciteA } from '../Elements';
+
+// Icons
+
+// Third party libraries
 
 const StyledBreadcrumbs = styled.nav`
   ${fontSize(-2)};

--- a/src/Button/Button-styled.js
+++ b/src/Button/Button-styled.js
@@ -9,11 +9,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.​
 
+// styled-components
 import styled, { css } from 'styled-components';
+
+// Utils, common elements
 import { unitCalc, fontSize } from '../utils/helpers';
 
-// Calcite theme
+// Calcite theme and Esri colors
 import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
+// Calcite components
+
+// Icons
+
+// Third party libraries
 
 const StyledButton = styled.button`
   position: relative;

--- a/src/Button/Button-styled.js
+++ b/src/Button/Button-styled.js
@@ -12,6 +12,9 @@
 import styled, { css } from 'styled-components';
 import { unitCalc, fontSize } from '../utils/helpers';
 
+// Calcite theme
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
 const StyledButton = styled.button`
   position: relative;
   display: inline-flex;
@@ -309,10 +312,12 @@ const StyledButton = styled.button`
       border-radius: 0;
     `};
 `;
+StyledButton.defaultProps = { theme };
 
 const StyledButtonGroup = styled.nav`
   display: inline-flex;
   justify-content: space-between;
 `;
+StyledButtonGroup.defaultProps = { theme };
 
 export { StyledButton, StyledButtonGroup };

--- a/src/Card/Card-styled.js
+++ b/src/Card/Card-styled.js
@@ -13,6 +13,9 @@ import styled, { css } from 'styled-components';
 import { CalciteFigure, CalciteH4 } from '../Elements';
 import { fontSize } from '../utils/helpers';
 
+// Calcite theme
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
 const StyledCard = styled.div`
   display: flex;
   flex-direction: column;
@@ -42,6 +45,7 @@ const StyledCard = styled.div`
       background: transparent;
     `};
 `;
+StyledCard.defaultProps = { theme };
 
 const StyledCardContent = styled.div`
   padding: 1rem;
@@ -66,6 +70,7 @@ const StyledCardContent = styled.div`
       border-radius: ${props => props.theme.borderRadius};
     `};
 `;
+StyledCardContent.defaultProps = { theme };
 
 const StyledCardImageWrap = styled(CalciteFigure)`
   width: 100%;
@@ -93,6 +98,7 @@ const StyledCardImageWrap = styled(CalciteFigure)`
       margin-bottom: 0;
     `};
 `;
+StyledCardImageWrap.defaultProps = { theme };
 
 const StyledCardImage = styled.img`
   width: 100%;
@@ -110,6 +116,7 @@ const StyledCardImage = styled.img`
       position: absolute;
     `};
 `;
+StyledCardImage.defaultProps = { theme };
 
 const StyledCardImageCaption = styled.figcaption`
   background: ${props => props.theme.palette.opaqueWhite};
@@ -123,10 +130,12 @@ const StyledCardImageCaption = styled.figcaption`
   ${fontSize(-2)};
   padding: 0.35rem 1.25rem 0.35rem 1.25rem;
 `;
+StyledCardImageCaption.defaultProps = { theme };
 
 const StyledCardTitle = styled(CalciteH4)`
   margin-bottom: 0.775rem;
 `;
+StyledCardTitle.defaultProps = { theme };
 
 export {
   StyledCard,

--- a/src/Card/Card-styled.js
+++ b/src/Card/Card-styled.js
@@ -9,12 +9,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.​
 
+// styled-components
 import styled, { css } from 'styled-components';
-import { CalciteFigure, CalciteH4 } from '../Elements';
+
+// Utils, common elements
 import { fontSize } from '../utils/helpers';
 
-// Calcite theme
+// Calcite theme and Esri colors
 import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
+// Calcite components
+import { CalciteFigure, CalciteH4 } from '../Elements';
+
+// Icons
+
+// Third party libraries
 
 const StyledCard = styled.div`
   display: flex;

--- a/src/Checkbox/Checkbox-styled.js
+++ b/src/Checkbox/Checkbox-styled.js
@@ -9,13 +9,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.​
 
+// styled-components
 import styled from 'styled-components';
-import { fontSize, unitCalc } from '../utils/helpers';
 
-// Calcite theme
+// Utils, common elements
+import { fontSize, unitCalc } from '../utils/helpers';
+import { baseRadioCheckbox } from '../utils/commonElements';
+
+// Calcite theme and Esri colors
 import { CalciteTheme as theme } from '../CalciteThemeProvider';
 
-import { baseRadioCheckbox } from '../utils/commonElements';
+// Calcite components
+
+// Icons
+
+// Third party libraries
 
 const StyledCheckbox = styled(baseRadioCheckbox)`
   -webkit-appearance: checkbox;

--- a/src/Checkbox/Checkbox-styled.js
+++ b/src/Checkbox/Checkbox-styled.js
@@ -12,6 +12,9 @@
 import styled from 'styled-components';
 import { fontSize, unitCalc } from '../utils/helpers';
 
+// Calcite theme
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
 import { baseRadioCheckbox } from '../utils/commonElements';
 
 const StyledCheckbox = styled(baseRadioCheckbox)`
@@ -19,6 +22,7 @@ const StyledCheckbox = styled(baseRadioCheckbox)`
   margin-right: ${props => unitCalc(props.theme.baseline, 4, '/')};
   cursor: pointer;
 `;
+StyledCheckbox.defaultProps = { theme };
 
 const StyledCheckboxLabel = styled.span`
   ${fontSize(-1)};
@@ -27,9 +31,11 @@ const StyledCheckboxLabel = styled.span`
   margin-right: ${props => props.theme.baseline};
   cursor: pointer;
 `;
+StyledCheckboxLabel.defaultProps = { theme };
 const StyledCheckboxGroup = styled.label`
   display: flex;
   align-items: center;
 `;
+StyledCheckboxGroup.defaultProps = { theme };
 
 export { StyledCheckbox, StyledCheckboxLabel, StyledCheckboxGroup };

--- a/src/ComboButton/ComboButton-styled.js
+++ b/src/ComboButton/ComboButton-styled.js
@@ -9,12 +9,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.​
 
+// styled-components
 import styled, { css } from 'styled-components';
-import { StyledButton } from '../Button/Button-styled';
+
+// Utils, common elements
 import { unitCalc } from '../utils/helpers';
 
-// Calcite theme
+// Calcite theme and Esri colors
 import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
+// Calcite components
+import { StyledButton } from '../Button/Button-styled';
+
+// Icons
+
+// Third party libraries
 
 const StyledComboButtonContainer = styled.div`
   display: flex;

--- a/src/ComboButton/ComboButton-styled.js
+++ b/src/ComboButton/ComboButton-styled.js
@@ -13,16 +13,21 @@ import styled, { css } from 'styled-components';
 import { StyledButton } from '../Button/Button-styled';
 import { unitCalc } from '../utils/helpers';
 
+// Calcite theme
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
 const StyledComboButtonContainer = styled.div`
   display: flex;
   flex-wrap: nowrap;
 `;
+StyledComboButtonContainer.defaultProps = { theme };
 
 const StyledComboButton = styled(StyledButton)`
   border-right-width: 0;
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;
 `;
+StyledComboButton.defaultProps = { theme };
 
 const StyledComboButtonDropdown = styled(StyledButton)`
   height: 100%;
@@ -58,6 +63,7 @@ const StyledComboButtonDropdown = styled(StyledButton)`
       border-left-color: ${props => props.theme.palette.darkGreen};
     `};
 `;
+StyledComboButtonDropdown.defaultProps = { theme };
 
 export {
   StyledComboButtonContainer,

--- a/src/CopyToClipboard/CopyToClipboard-styled.js
+++ b/src/CopyToClipboard/CopyToClipboard-styled.js
@@ -9,13 +9,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.​
 
+// styled-components
 import styled, { keyframes } from 'styled-components';
-import { CalciteInput } from '../utils/commonElements';
+
+// Utils, common elements
 import { transition } from '../utils/helpers';
+import { CalciteInput } from '../utils/commonElements';
+
+// Calcite theme and Esri colors
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
+// Calcite components
 import Button from '../Button';
 
-// Calcite theme
-import { CalciteTheme as theme } from '../CalciteThemeProvider';
+// Icons
+
+// Third party libraries
 
 const FadeIn = keyframes`
   from {

--- a/src/CopyToClipboard/CopyToClipboard-styled.js
+++ b/src/CopyToClipboard/CopyToClipboard-styled.js
@@ -14,6 +14,9 @@ import { CalciteInput } from '../utils/commonElements';
 import { transition } from '../utils/helpers';
 import Button from '../Button';
 
+// Calcite theme
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
 const FadeIn = keyframes`
   from {
     opacity: 0;
@@ -30,6 +33,7 @@ const StyledCopyToClipboard = styled.div`
     animation: ${FadeIn} ${transition()};
   }
 `;
+StyledCopyToClipboard.defaultProps = { theme };
 
 const StyledCopyToClipboardInput = styled(CalciteInput)`
   flex: 1 0 50px;
@@ -39,6 +43,7 @@ const StyledCopyToClipboardInput = styled(CalciteInput)`
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;
 `;
+StyledCopyToClipboardInput.defaultProps = { theme };
 
 const StyledCopyButton = styled(Button)`
   border-top-left-radius: 0;
@@ -48,5 +53,6 @@ const StyledCopyButton = styled(Button)`
     margin-left: 0 !important;
   }
 `;
+StyledCopyButton.defaultProps = { theme };
 
 export { StyledCopyToClipboard, StyledCopyToClipboardInput, StyledCopyButton };

--- a/src/DatePicker/DatePicker-styled.js
+++ b/src/DatePicker/DatePicker-styled.js
@@ -9,11 +9,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.​
 
+// styled-components
 import styled from 'styled-components';
+
+// Utils, common elements
+
+// Calcite theme and Esri colors
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
+// Calcite components
 import Select from '../Select';
 
-// Calcite theme
-import { CalciteTheme as theme } from '../CalciteThemeProvider';
+// Icons
+
+// Third party libraries
 
 const StyledDatePickerContainer = styled.div`
   position: relative;

--- a/src/DatePicker/DatePicker-styled.js
+++ b/src/DatePicker/DatePicker-styled.js
@@ -146,12 +146,14 @@ const StyledMonthSelect = styled(Select).attrs({
   background-size: 11px;
   background-position: right 5px center;
 `;
+StyledMonthSelect.defaultProps = { theme };
 
 const StyledYearSelect = styled(StyledMonthSelect).attrs({
   virtualized: true
 })`
   margin-left: 10px;
 `;
+StyledYearSelect.defaultProps = { theme };
 
 const StyledMonthYearHeader = styled.h6`
   color: #565a5c;

--- a/src/DatePicker/DatePicker-styled.js
+++ b/src/DatePicker/DatePicker-styled.js
@@ -12,6 +12,9 @@
 import styled from 'styled-components';
 import Select from '../Select';
 
+// Calcite theme
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
 const StyledDatePickerContainer = styled.div`
   position: relative;
   font-family: ${props => props.theme.type.avenirFamily};
@@ -102,12 +105,14 @@ const StyledDatePickerContainer = styled.div`
     align-items: center;
   }
 `;
+StyledDatePickerContainer.defaultProps = { theme };
 
 const StyledMonthElContainer = styled.div`
   display: flex;
   flex-direction: column;
   margin-bottom: -37px;
 `;
+StyledMonthElContainer.defaultProps = { theme };
 
 const StyledMonthYearSelectContainer = styled.div`
   display: flex;
@@ -116,6 +121,7 @@ const StyledMonthYearSelectContainer = styled.div`
   margin: -4px 0 5px;
   min-height: 32px;
 `;
+StyledMonthYearSelectContainer.defaultProps = { theme };
 
 const StyledMonthSelect = styled(Select).attrs({
   menuStyle: { minWidth: '100%', maxHeight: '200px' },
@@ -145,6 +151,7 @@ const StyledMonthYearHeader = styled.h6`
   caption-side: initial;
   margin: 0 3px;
 `;
+StyledMonthYearHeader.defaultProps = { theme };
 
 const StyledWeekDayList = styled.ol`
   text-decoration: none;
@@ -155,12 +162,14 @@ const StyledWeekDayList = styled.ol`
   padding: 0;
   margin: 0;
 `;
+StyledWeekDayList.defaultProps = { theme };
 
 const StyledWeekDay = styled.li`
   color: ${props => props.theme.palette.darkerGray};
   font-size: smaller;
   width: 39px;
 `;
+StyledWeekDay.defaultProps = { theme };
 
 export {
   StyledDatePickerContainer,

--- a/src/Drawer/Drawer-styled.js
+++ b/src/Drawer/Drawer-styled.js
@@ -9,11 +9,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.​
 
+// styled-components
 import styled, { css } from 'styled-components';
+
+// Utils, common elements
 import { transition } from '../utils/helpers';
 
-// Calcite theme
+// Calcite theme and Esri colors
 import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
+// Calcite components
+
+// Icons
+
+// Third party libraries
 
 const StyledDrawer = styled.div`
   position: fixed;

--- a/src/Drawer/Drawer-styled.js
+++ b/src/Drawer/Drawer-styled.js
@@ -12,6 +12,9 @@
 import styled, { css } from 'styled-components';
 import { transition } from '../utils/helpers';
 
+// Calcite theme
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
 const StyledDrawer = styled.div`
   position: fixed;
   top: 0;
@@ -33,6 +36,7 @@ const StyledDrawer = styled.div`
       background-color: ${props => props.theme.palette.transparentBlack};
     `};
 `;
+StyledDrawer.defaultProps = { theme };
 
 const StyledDrawerNav = styled.nav`
   position: absolute;
@@ -68,5 +72,6 @@ const StyledDrawerNav = styled.nav`
         `};
     `};
 `;
+StyledDrawerNav.defaultProps = { theme };
 
 export { StyledDrawer, StyledDrawerNav };

--- a/src/Elements/Elements-styled.js
+++ b/src/Elements/Elements-styled.js
@@ -13,12 +13,16 @@ import React from 'react';
 import styled, { css } from 'styled-components';
 import { fontSize, unitCalc } from '../utils/helpers';
 
+// Calcite theme
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
 const CalciteHtml = styled.html`
   height: 100%;
   font-size: 100%;
   font-family: 'Avenir Next W01', 'Avenir Next W00', 'Avenir Next', 'Avenir',
     'Helvetica Neue', sans-serif;
 `;
+CalciteHtml.defaultProps = { theme };
 CalciteHtml.displayName = 'CalciteHtml';
 
 const CalciteBody = styled.body`
@@ -40,12 +44,14 @@ const CalciteBody = styled.body`
   text-rendering: optimizeLegibility;
   font-feature-settings: 'liga' 1, 'calt' 0;
 `;
+CalciteBody.defaultProps = { theme };
 CalciteBody.displayName = 'CalciteBody';
 
 const CalciteP = styled.p`
   margin-top: 0;
   margin-bottom: 1.55rem;
 `;
+CalciteP.defaultProps = { theme };
 CalciteP.displayName = 'CalciteP';
 
 const CalciteA = styled.a`
@@ -58,6 +64,7 @@ const CalciteA = styled.a`
     text-decoration: underline;
   }
 `;
+CalciteA.defaultProps = { theme };
 CalciteA.displayName = 'CalciteA';
 
 const baseH = styled.h1`
@@ -65,6 +72,7 @@ const baseH = styled.h1`
   font-style: normal;
   margin: 0 0 ${props => props.theme.baseline} 0;
 `;
+baseH.defaultProps = { theme };
 
 const H1 = styled(baseH)`
   ${fontSize(5)};
@@ -159,6 +167,7 @@ const BaseList = styled.div`
       }
     `};
 `;
+BaseList.defaultProps = { theme };
 
 const CalciteOl = ({ children, ...props }) => {
   return (
@@ -188,11 +197,13 @@ const CalciteLi = styled.li`
     margin-bottom: 0;
   }
 `;
+CalciteLi.defaultProps = { theme };
 CalciteLi.displayName = 'CalciteLi';
 
 const CalciteFigure = styled.figure`
   margin: 0 0 1.55rem 0;
 `;
+CalciteFigure.defaultProps = { theme };
 CalciteFigure.displayName = 'CalciteFigure';
 
 export {

--- a/src/Elements/Elements-styled.js
+++ b/src/Elements/Elements-styled.js
@@ -10,11 +10,20 @@
 // limitations under the License.​
 
 import React from 'react';
+// styled-components
 import styled, { css } from 'styled-components';
+
+// Utils, common elements
 import { fontSize, unitCalc } from '../utils/helpers';
 
-// Calcite theme
+// Calcite theme and Esri colors
 import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
+// Calcite components
+
+// Icons
+
+// Third party libraries
 
 const CalciteHtml = styled.html`
   height: 100%;

--- a/src/FileUploader/FileUploader-styled.js
+++ b/src/FileUploader/FileUploader-styled.js
@@ -13,6 +13,8 @@ import styled from 'styled-components';
 import { CalciteInput } from '../utils/commonElements';
 import { unitCalc, fontSize } from '../utils/helpers';
 
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
 const StyledFileUploader = styled(CalciteInput)`
   height: auto;
 
@@ -89,5 +91,6 @@ const StyledFileUploader = styled(CalciteInput)`
     margin: 0.5em 0;
   }
 `;
+StyledFileUploader.defaultProps = { theme };
 
 export { StyledFileUploader };

--- a/src/Form/Form-styled.js
+++ b/src/Form/Form-styled.js
@@ -12,6 +12,9 @@
 import styled, { css } from 'styled-components';
 import { fontSize, unitCalc } from '../utils/helpers';
 
+// Calcite theme
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
 const StyledForm = styled.form`
   margin: 0;
   padding: 0;
@@ -25,6 +28,7 @@ const StyledForm = styled.form`
       flex-direction: row;
     `};
 `;
+StyledForm.defaultProps = { theme };
 
 const StyledFormControl = styled.div`
   position: relative;
@@ -61,6 +65,7 @@ const StyledFormControl = styled.div`
       width: 100%;
     `};
 `;
+StyledFormControl.defaultProps = { theme };
 
 const StyledFormControlLabel = styled.label`
   display: flex;
@@ -73,6 +78,7 @@ const StyledFormControlLabel = styled.label`
       align-items: center;
     `};
 `;
+StyledFormControlLabel.defaultProps = { theme };
 
 const StyledFormControlLabelText = styled.span`
   ${props =>
@@ -81,6 +87,7 @@ const StyledFormControlLabelText = styled.span`
       margin-right: ${props => unitCalc(props.theme.baseline, 2, '/')};
     `};
 `;
+StyledFormControlLabelText.defaultProps = { theme };
 
 const StyledFormHelperText = styled.span`
   ${fontSize(-3)};
@@ -100,6 +107,7 @@ const StyledFormHelperText = styled.span`
       color: ${props => props.theme.palette.darkGreen200};
     `};
 `;
+StyledFormHelperText.defaultProps = { theme };
 
 const StyledLegend = styled.legend`
   position: relative;
@@ -113,6 +121,7 @@ const StyledLegend = styled.legend`
       margin-bottom: 0;
     `};
 `;
+StyledLegend.defaultProps = { theme };
 
 const StyledFieldset = styled.div`
   margin: 0;
@@ -127,6 +136,7 @@ const StyledFieldset = styled.div`
       flex-direction: row;
     `};
 `;
+StyledFieldset.defaultProps = { theme };
 
 export {
   StyledForm,

--- a/src/Form/Form-styled.js
+++ b/src/Form/Form-styled.js
@@ -9,11 +9,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.​
 
+// styled-components
 import styled, { css } from 'styled-components';
+
+// Utils, common elements
 import { fontSize, unitCalc } from '../utils/helpers';
 
-// Calcite theme
+// Calcite theme and Esri colors
 import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
+// Calcite components
+
+// Icons
+
+// Third party libraries
 
 const StyledForm = styled.form`
   margin: 0;

--- a/src/Label/Label-styled.js
+++ b/src/Label/Label-styled.js
@@ -9,12 +9,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.​
 
+// styled-components
 import styled, { css } from 'styled-components';
 
-// Calcite theme
+// Utils, common elements
+import { fontSize } from '../utils/helpers';
+
+// Calcite theme and Esri colors
 import { CalciteTheme as theme } from '../CalciteThemeProvider';
 
-import { fontSize } from '../utils/helpers';
+// Calcite components
+
+// Icons
+
+// Third party libraries
 
 const StyledLabel = styled.mark`
   background-color: ${props => props.theme.palette.lightestGray};

--- a/src/Label/Label-styled.js
+++ b/src/Label/Label-styled.js
@@ -10,6 +10,10 @@
 // limitations under the License.​
 
 import styled, { css } from 'styled-components';
+
+// Calcite theme
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
 import { fontSize } from '../utils/helpers';
 
 const StyledLabel = styled.mark`
@@ -47,5 +51,6 @@ const StyledLabel = styled.mark`
       color: ${props => props.theme.palette.white};
     `};
 `;
+StyledLabel.defaultProps = { theme };
 
 export { StyledLabel };

--- a/src/List/List-styled.js
+++ b/src/List/List-styled.js
@@ -11,6 +11,10 @@
 
 import styled, { css } from 'styled-components';
 import { StyledSideNav } from '../SideNav/SideNav-styled';
+
+// Calcite theme
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
 import { unitCalc, fontSize } from '../utils/helpers';
 
 const StyledList = styled(StyledSideNav)`
@@ -59,6 +63,7 @@ const StyledList = styled(StyledSideNav)`
         `};
     `};
 `;
+StyledList.defaultProps = { theme };
 
 const getActiveStyles = props => {
   return `
@@ -236,6 +241,7 @@ const StyledListItem = styled.div`
         `};
     `};
 `;
+StyledListItem.defaultProps = { theme };
 
 const StyledListHeader = styled(StyledListItem)`
   flex-shrink: 0;
@@ -257,12 +263,14 @@ const StyledListHeader = styled(StyledListItem)`
       }
     `};
 `;
+StyledListHeader.defaultProps = { theme };
 
 const StyledListTitle = styled.p`
   ${fontSize(-1)};
   flex-shrink: 0;
   margin: 0;
 `;
+StyledListTitle.defaultProps = { theme };
 
 const StyledListSubtitle = styled.span`
   ${fontSize(-3)};
@@ -270,6 +278,7 @@ const StyledListSubtitle = styled.span`
   line-height: 1.2rem;
   color: ${props => props.theme.palette.gray};
 `;
+StyledListSubtitle.defaultProps = { theme };
 
 const StyledListTextContainer = styled.div`
   display: flex;
@@ -278,6 +287,7 @@ const StyledListTextContainer = styled.div`
   flex-direction: column;
   justify-content: center;
 `;
+StyledListTextContainer.defaultProps = { theme };
 
 const StyledListSideContainer = styled.div`
   display: flex;
@@ -344,6 +354,7 @@ const StyledListSideContainer = styled.div`
       `};
   }
 `;
+StyledListSideContainer.defaultProps = { theme };
 
 export {
   StyledList,

--- a/src/List/List-styled.js
+++ b/src/List/List-styled.js
@@ -9,13 +9,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.​
 
+// styled-components
 import styled, { css } from 'styled-components';
-import { StyledSideNav } from '../SideNav/SideNav-styled';
 
-// Calcite theme
+// Utils, common elements
+import { unitCalc, fontSize } from '../utils/helpers';
+
+// Calcite theme and Esri colors
 import { CalciteTheme as theme } from '../CalciteThemeProvider';
 
-import { unitCalc, fontSize } from '../utils/helpers';
+// Calcite components
+import { StyledSideNav } from '../SideNav/SideNav-styled';
+
+// Icons
+
+// Third party libraries
 
 const StyledList = styled(StyledSideNav)`
   min-width: 200px;

--- a/src/Loader/Loader-styled.js
+++ b/src/Loader/Loader-styled.js
@@ -10,8 +10,11 @@
 // limitations under the License.​
 
 import styled, { css, keyframes } from 'styled-components';
+
+// Calcite theme
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
 import { unitCalc } from '../utils/helpers';
-import { CalciteTheme } from '../CalciteThemeProvider';
 
 const loaderVariables = {
   loaderWidth: '0.85em',
@@ -20,7 +23,7 @@ const loaderVariables = {
   loaderSpacing: '1.25em',
   loaderSpeed: '0.8s',
   loaderDelay: '0.16s',
-  loaderBlue: CalciteTheme.palette.blue
+  loaderBlue: theme.palette.blue
 };
 
 const loadKeyframes = color => keyframes`
@@ -64,6 +67,7 @@ const StyledLoader = styled.div`
   position: relative;
   min-height: ${props => props.sizeRatio * 3}px;
 `;
+StyledLoader.defaultProps = { theme };
 
 const StyledLoaderBars = styled.div`
   ${props => loaderStyles(props.color)};
@@ -88,10 +92,12 @@ const StyledLoaderBars = styled.div`
     animation-delay: ${unitCalc(loaderVariables.loaderDelay, 2, '*')};
   }
 `;
+StyledLoaderBars.defaultProps = { theme };
 
 const StyledLoaderText = styled.div`
   text-align: center;
   padding-top: ${props => props.sizeRatio * 3.5}px;
 `;
+StyledLoaderText.defaultProps = { theme };
 
 export { StyledLoader, StyledLoaderBars, StyledLoaderText };

--- a/src/Loader/Loader-styled.js
+++ b/src/Loader/Loader-styled.js
@@ -9,12 +9,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.​
 
+// styled-components
 import styled, { css, keyframes } from 'styled-components';
 
-// Calcite theme
+// Utils, common elements
+import { unitCalc } from '../utils/helpers';
+
+// Calcite theme and Esri colors
 import { CalciteTheme as theme } from '../CalciteThemeProvider';
 
-import { unitCalc } from '../utils/helpers';
+// Calcite components
+
+// Icons
+
+// Third party libraries
 
 const loaderVariables = {
   loaderWidth: '0.85em',

--- a/src/Menu/Menu-styled.js
+++ b/src/Menu/Menu-styled.js
@@ -9,14 +9,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.​
 
+// styled-components
 import styled, { css } from 'styled-components';
+
+// Utils, common elements
+import { unitCalc, fontSize } from '../utils/helpers';
+
+// Calcite theme and Esri colors
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
+// Calcite components
 import { StyledSideNav } from '../SideNav/SideNav-styled';
 import { CalciteA } from '../Elements';
 
-// Calcite theme
-import { CalciteTheme as theme } from '../CalciteThemeProvider';
+// Icons
 
-import { unitCalc, fontSize } from '../utils/helpers';
+// Third party libraries
 
 const StyledMenu = styled(StyledSideNav)`
   min-width: 200px;

--- a/src/Menu/Menu-styled.js
+++ b/src/Menu/Menu-styled.js
@@ -12,6 +12,10 @@
 import styled, { css } from 'styled-components';
 import { StyledSideNav } from '../SideNav/SideNav-styled';
 import { CalciteA } from '../Elements';
+
+// Calcite theme
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
 import { unitCalc, fontSize } from '../utils/helpers';
 
 const StyledMenu = styled(StyledSideNav)`
@@ -54,6 +58,7 @@ const StyledMenu = styled(StyledSideNav)`
       ${fontSize(2)};
     `};
 `;
+StyledMenu.defaultProps = { theme };
 
 const StyledMenuItem = styled(CalciteA)`
   position: relative;
@@ -131,12 +136,14 @@ const StyledMenuItem = styled(CalciteA)`
       font-weight: 300;
     `};
 `;
+StyledMenuItem.defaultProps = { theme };
 
 const StyledMenuTitle = styled(StyledMenuItem)`
   font-size: 1em;
   background-color: ${props => props.theme.palette.offWhite};
   cursor: auto;
 `;
+StyledMenuTitle.defaultProps = { theme };
 
 const StyledMenuItemSubtitle = styled.span`
   font-size: 0.85em;
@@ -146,5 +153,6 @@ const StyledMenuItemSubtitle = styled.span`
     color: ${props => props.theme.palette.lightGray};
   }
 `;
+StyledMenuItemSubtitle.defaultProps = { theme };
 
 export { StyledMenu, StyledMenuItem, StyledMenuTitle, StyledMenuItemSubtitle };

--- a/src/Modal/Modal-styled.js
+++ b/src/Modal/Modal-styled.js
@@ -9,10 +9,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.​
 
+// styled-components
 import styled from 'styled-components';
 
-// Calcite theme
+// Utils, common elements
+
+// Calcite theme and Esri colors
 import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
+// Calcite components
+
+// Icons
+
+// Third party libraries
 
 const StyledModalOverlay = {
   display: 'flex',

--- a/src/Modal/Modal-styled.js
+++ b/src/Modal/Modal-styled.js
@@ -10,7 +10,9 @@
 // limitations under the License.​
 
 import styled from 'styled-components';
-import { CalciteTheme } from '../CalciteThemeProvider';
+
+// Calcite theme
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
 
 const StyledModalOverlay = {
   display: 'flex',
@@ -22,7 +24,7 @@ const StyledModalOverlay = {
   right: '0px',
   bottom: '0px',
   textAlign: 'center',
-  background: CalciteTheme.palette.transparentBlack,
+  background: theme.palette.transparentBlack,
   zIndex: 101,
   transition: `opacity 300ms cubic-bezier(0.4, 0.0, 0.2, 1)`,
   opacity: 0
@@ -40,13 +42,13 @@ const StyledModalDialog = {
   outline: 'none',
   boxSizing: 'border-box',
   zIndex: '102',
-  background: CalciteTheme.palette.white,
-  padding: CalciteTheme.baseline,
+  background: theme.palette.white,
+  padding: theme.baseline,
   textAlign: 'left',
   overflowY: 'auto',
   display: 'inline-block',
   verticalAlign: 'middle',
-  borderRadius: CalciteTheme.borderRadius,
+  borderRadius: theme.borderRadius,
   border: 'none',
   transition: `margin-top 300ms cubic-bezier(0.4, 0.0, 0.2, 1)`,
   marginTop: '30px'
@@ -57,6 +59,7 @@ const StyledModalActions = styled.div`
   justify-content: flex-end;
   align-items: center;
 `;
+StyledModalActions.defaultProps = { theme };
 
 const OverlayTransition = {
   entering: { opacity: 0 },

--- a/src/MultiSelect/MultiSelect-styled.js
+++ b/src/MultiSelect/MultiSelect-styled.js
@@ -12,11 +12,16 @@
 import styled, { css } from 'styled-components';
 import { CalciteSelect } from '../utils/commonElements';
 import Menu from '../Menu';
+
+// Calcite theme
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
 import { transition } from '../utils/helpers';
 
 const StyledMultiSelectWrapper = styled.div`
   position: relative;
 `;
+StyledMultiSelectWrapper.defaultProps = { theme };
 
 const StyledMultiSelectButton = styled(CalciteSelect)`
   cursor: pointer;
@@ -25,6 +30,7 @@ const StyledMultiSelectButton = styled(CalciteSelect)`
   text-overflow: ellipsis;
   text-align: left;
 `;
+StyledMultiSelectButton.defaultProps = { theme };
 
 const StyledMultiSelectMenu = styled(Menu)`
   max-height: 300px;
@@ -47,6 +53,7 @@ const StyledMultiSelectMenu = styled(Menu)`
       width: 100%;
     `};
 `;
+StyledMultiSelectMenu.defaultProps = { theme };
 
 export {
   StyledMultiSelectWrapper,

--- a/src/MultiSelect/MultiSelect-styled.js
+++ b/src/MultiSelect/MultiSelect-styled.js
@@ -9,14 +9,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.​
 
+// styled-components
 import styled, { css } from 'styled-components';
-import { CalciteSelect } from '../utils/commonElements';
-import Menu from '../Menu';
 
-// Calcite theme
+// Utils, common elements
+import { transition } from '../utils/helpers';
+import { CalciteSelect } from '../utils/commonElements';
+
+// Calcite theme and Esri colors
 import { CalciteTheme as theme } from '../CalciteThemeProvider';
 
-import { transition } from '../utils/helpers';
+// Calcite components
+import Menu from '../Menu';
+
+// Icons
+
+// Third party libraries
 
 const StyledMultiSelectWrapper = styled.div`
   position: relative;

--- a/src/Panel/Panel-styled.js
+++ b/src/Panel/Panel-styled.js
@@ -9,12 +9,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.​
 
+// styled-components
 import styled, { css } from 'styled-components';
+
+// Utils, common elements
 import { unitCalc, clearfix } from '../utils/helpers';
+
+// Calcite theme and Esri colors
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
+// Calcite components
 import { CalciteH4 } from '../Elements';
 
-// Calcite theme
-import { CalciteTheme as theme } from '../CalciteThemeProvider';
+// Icons
+
+// Third party libraries
 
 const StyledPanel = styled.div`
   ${clearfix()};

--- a/src/Panel/Panel-styled.js
+++ b/src/Panel/Panel-styled.js
@@ -13,6 +13,9 @@ import styled, { css } from 'styled-components';
 import { unitCalc, clearfix } from '../utils/helpers';
 import { CalciteH4 } from '../Elements';
 
+// Calcite theme
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
 const StyledPanel = styled.div`
   ${clearfix()};
   background-color: ${props => props.theme.palette.offWhite};
@@ -87,11 +90,14 @@ const StyledPanel = styled.div`
       padding: 0;
     `};
 `;
+StyledPanel.defaultProps = { theme };
 
 const StyledPanelText = styled.div``;
+StyledPanelText.defaultProps = { theme };
 
 const StyledPanelTitle = styled(CalciteH4)`
   margin-bottom: 0.775rem;
 `;
+StyledPanelTitle.defaultProps = { theme };
 
 export { StyledPanel, StyledPanelText, StyledPanelTitle };

--- a/src/Popover/Popover-styled.js
+++ b/src/Popover/Popover-styled.js
@@ -9,10 +9,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.​
 
+// styled-components
 import styled, { css } from 'styled-components';
 
-// Calcite theme
+// Utils, common elements
+
+// Calcite theme and Esri colors
 import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
+// Calcite components
+
+// Icons
+
+// Third party libraries
 
 const StyledTargetWrapper = styled.div`
   display: inline-block;

--- a/src/Popover/Popover-styled.js
+++ b/src/Popover/Popover-styled.js
@@ -11,9 +11,13 @@
 
 import styled, { css } from 'styled-components';
 
+// Calcite theme
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
 const StyledTargetWrapper = styled.div`
   display: inline-block;
 `;
+StyledTargetWrapper.defaultProps = { theme };
 
 const StyledPopover = styled.div`
   box-shadow: 0 0 16px 0 rgba(0, 0, 0, 0.05);
@@ -41,5 +45,6 @@ const StyledPopover = styled.div`
       pointer-events: auto;
     `};
 `;
+StyledPopover.defaultProps = { theme };
 
 export { StyledTargetWrapper, StyledPopover };

--- a/src/Radio/Radio-styled.js
+++ b/src/Radio/Radio-styled.js
@@ -10,8 +10,11 @@
 // limitations under the License.​
 
 import styled from 'styled-components';
-import { fontSize, unitCalc } from '../utils/helpers';
 
+// Calcite theme
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
+import { fontSize, unitCalc } from '../utils/helpers';
 import { baseRadioCheckbox } from '../utils/commonElements';
 
 const StyledRadio = styled(baseRadioCheckbox)`
@@ -20,6 +23,7 @@ const StyledRadio = styled(baseRadioCheckbox)`
   margin-right: ${props => unitCalc(props.theme.baseline, 4, '/')};
   cursor: pointer;
 `;
+StyledRadio.defaultProps = { theme };
 
 const StyledRadioLabel = styled.span`
   ${fontSize(-1)};
@@ -28,9 +32,11 @@ const StyledRadioLabel = styled.span`
   margin-right: ${props => props.theme.baseline};
   cursor: pointer;
 `;
+StyledRadioLabel.defaultProps = { theme };
 const StyledRadioGroup = styled.label`
   display: flex;
   align-items: center;
 `;
+StyledRadioGroup.defaultProps = { theme };
 
 export { StyledRadio, StyledRadioLabel, StyledRadioGroup };

--- a/src/Radio/Radio-styled.js
+++ b/src/Radio/Radio-styled.js
@@ -9,13 +9,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.​
 
+// styled-components
 import styled from 'styled-components';
 
-// Calcite theme
-import { CalciteTheme as theme } from '../CalciteThemeProvider';
-
+// Utils, common elements
 import { fontSize, unitCalc } from '../utils/helpers';
 import { baseRadioCheckbox } from '../utils/commonElements';
+
+// Calcite theme and Esri colors
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
+// Calcite components
+
+// Icons
+
+// Third party libraries
 
 const StyledRadio = styled(baseRadioCheckbox)`
   -webkit-appearance: radio;

--- a/src/Search/Search-styled.js
+++ b/src/Search/Search-styled.js
@@ -9,13 +9,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.​
 
+// styled-components
 import styled, { css } from 'styled-components';
 
-// Calcite theme
+// Utils, common elements
+import { fontSize, unitCalc, transition } from '../utils/helpers';
+import { CalciteInput } from '../utils/commonElements';
+
+// Calcite theme and Esri colors
 import { CalciteTheme as theme } from '../CalciteThemeProvider';
 
-import { CalciteInput } from '../utils/commonElements';
-import { fontSize, unitCalc, transition } from '../utils/helpers';
+// Calcite components
+
+// Icons
+
+// Third party libraries
 
 const StyledClearIconContainer = styled.div`
   display: none;

--- a/src/Search/Search-styled.js
+++ b/src/Search/Search-styled.js
@@ -10,6 +10,10 @@
 // limitations under the License.​
 
 import styled, { css } from 'styled-components';
+
+// Calcite theme
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
 import { CalciteInput } from '../utils/commonElements';
 import { fontSize, unitCalc, transition } from '../utils/helpers';
 
@@ -26,6 +30,7 @@ const StyledClearIconContainer = styled.div`
     opacity: 0.8;
   }
 `;
+StyledClearIconContainer.defaultProps = { theme };
 
 const StyledSearchIconContainer = styled.span`
   position: absolute;
@@ -37,6 +42,7 @@ const StyledSearchIconContainer = styled.span`
   pointer-events: none;
   line-height: 0;
 `;
+StyledSearchIconContainer.defaultProps = { theme };
 
 const StyledShortcutCharacter = styled.div`
   position: absolute;
@@ -52,6 +58,7 @@ const StyledShortcutCharacter = styled.div`
   color: ${props => props.theme.palette.lightGray};
   border-radius: 1px;
 `;
+StyledShortcutCharacter.defaultProps = { theme };
 
 const StyledSearchContainer = styled.div`
   display: inline-flex;
@@ -97,11 +104,13 @@ const StyledSearchContainer = styled.div`
     }
   }
 `;
+StyledSearchContainer.defaultProps = { theme };
 
 const StyledSearchInputWrapper = styled.div`
   position: relative;
   flex: 1 0 50px;
 `;
+StyledSearchInputWrapper.defaultProps = { theme };
 
 const StyledSearch = styled(CalciteInput)`
   padding-right: ${props => props.theme.baseline};
@@ -139,6 +148,7 @@ const StyledSearch = styled(CalciteInput)`
       }
     `};
 `;
+StyledSearch.defaultProps = { theme };
 
 const ManagerStyle = {
   width: '100%'

--- a/src/Search/doc/StyledSearch.js
+++ b/src/Search/doc/StyledSearch.js
@@ -1,6 +1,9 @@
 import styled from 'styled-components';
 import Search from '../../Search';
 
+// Calcite theme
+import { CalciteTheme as theme } from '../../CalciteThemeProvider';
+
 const StyledSearch = styled(Search)`
   color: ${props => props.theme.palette.white};
   border-bottom-color: ${props => props.theme.palette.lightBlue};
@@ -13,5 +16,6 @@ const StyledSearch = styled(Search)`
     border-bottom-color: ${props => props.theme.palette.white};
   }
 `;
+StyledSearch.defaultProps = { theme };
 
 export default StyledSearch;

--- a/src/Search/doc/StyledSearch.js
+++ b/src/Search/doc/StyledSearch.js
@@ -1,7 +1,6 @@
 import styled from 'styled-components';
 import Search from '../../Search';
 
-// Calcite theme
 import { CalciteTheme as theme } from '../../CalciteThemeProvider';
 
 const StyledSearch = styled(Search)`

--- a/src/Select/Select-styled.js
+++ b/src/Select/Select-styled.js
@@ -9,14 +9,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.​
 
+// styled-components
 import styled, { css } from 'styled-components';
-import { CalciteSelect } from '../utils/commonElements';
-import Menu from '../Menu';
 
-// Calcite theme
+// Utils, common elements
+import { CalciteSelect } from '../utils/commonElements';
+import { transition } from '../utils/helpers';
+
+// Calcite theme and Esri colors
 import { CalciteTheme as theme } from '../CalciteThemeProvider';
 
-import { transition } from '../utils/helpers';
+// Calcite components
+import Menu from '../Menu';
+
+// Icons
+
+// Third party libraries
 
 const StyledSelectWrapper = styled.div`
   position: relative;

--- a/src/Select/Select-styled.js
+++ b/src/Select/Select-styled.js
@@ -12,6 +12,10 @@
 import styled, { css } from 'styled-components';
 import { CalciteSelect } from '../utils/commonElements';
 import Menu from '../Menu';
+
+// Calcite theme
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
 import { transition } from '../utils/helpers';
 
 const StyledSelectWrapper = styled.div`
@@ -23,11 +27,13 @@ const StyledSelectWrapper = styled.div`
       width: 100%;
     `};
 `;
+StyledSelectWrapper.defaultProps = { theme };
 
 const StyledSelectInput = styled(CalciteSelect)`
   cursor: pointer;
   text-overflow: ellipsis;
 `;
+StyledSelectInput.defaultProps = { theme };
 
 const StyledSelectButton = styled(CalciteSelect)`
   cursor: pointer;
@@ -36,6 +42,7 @@ const StyledSelectButton = styled(CalciteSelect)`
   white-space: nowrap;
   text-overflow: ellipsis;
 `;
+StyledSelectButton.defaultProps = { theme };
 
 const StyledSelectMenu = styled(Menu)`
   max-height: 300px;
@@ -58,6 +65,7 @@ const StyledSelectMenu = styled(Menu)`
       min-width: 100%;
     `};
 `;
+StyledSelectMenu.defaultProps = { theme };
 
 const PopperManagerStyles = {
   width: '100%'

--- a/src/SideNav/SideNav-styled.js
+++ b/src/SideNav/SideNav-styled.js
@@ -9,14 +9,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.​
 
+// styled-components
 import styled, { css } from 'styled-components';
-import { CalciteH4, CalciteA } from '../Elements';
 
-// Calcite theme
-import { CalciteTheme as theme } from '../CalciteThemeProvider';
-
+// Utils, common elements
 import { unitCalc, fontSize } from '../utils/helpers';
 import { avenirRegular } from '../utils/type';
+
+// Calcite theme and Esri colors
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
+// Calcite components
+import { CalciteH4, CalciteA } from '../Elements';
+
+// Icons
+
+// Third party libraries
 
 const StyledSideNav = styled.aside`
   box-sizing: border-box;

--- a/src/SideNav/SideNav-styled.js
+++ b/src/SideNav/SideNav-styled.js
@@ -11,6 +11,10 @@
 
 import styled, { css } from 'styled-components';
 import { CalciteH4, CalciteA } from '../Elements';
+
+// Calcite theme
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
 import { unitCalc, fontSize } from '../utils/helpers';
 import { avenirRegular } from '../utils/type';
 
@@ -23,6 +27,7 @@ const StyledSideNav = styled.aside`
   background-color: ${props => props.theme.palette.white};
   border-radius: ${props => props.theme.borderRadius};
 `;
+StyledSideNav.defaultProps = { theme };
 
 const StyledSideNavTitle = styled(CalciteH4)`
   margin: 0;
@@ -32,6 +37,7 @@ const StyledSideNavTitle = styled(CalciteH4)`
   background-color: ${props => props.theme.palette.offWhite};
   border-top: 1px solid ${props => props.theme.palette.lightestGray};
 `;
+StyledSideNavTitle.defaultProps = { theme };
 
 const StyledSideNavLink = styled(CalciteA)`
   position: relative;
@@ -64,5 +70,6 @@ const StyledSideNavLink = styled(CalciteA)`
       border-left: 3px solid ${props => props.theme.palette.blue};
     `};
 `;
+StyledSideNavLink.defaultProps = { theme };
 
 export { StyledSideNav, StyledSideNavTitle, StyledSideNavLink };

--- a/src/Slider/Slider-styled.js
+++ b/src/Slider/Slider-styled.js
@@ -12,39 +12,40 @@
 import styled, { css } from 'styled-components';
 import { transparentize } from 'polished';
 
-import { CalciteTheme, EsriColors } from '../CalciteThemeProvider';
+// Calcite theme
+import { CalciteTheme as theme, EsriColors } from '../CalciteThemeProvider';
 
 import { CalciteInput } from '../utils/commonElements';
 
 const rangeProps = {
   rangeBorder: '1px solid transparent',
-  trackBgColor: CalciteTheme.palette.lighterGray,
-  trackErrorBgColor: CalciteTheme.palette.lightRed,
+  trackBgColor: theme.palette.lighterGray,
+  trackErrorBgColor: theme.palette.lightRed,
   trackHeight: '2px',
-  trackHoverBgcolor: CalciteTheme.palette.lightGray,
-  trackErrorHoverBgcolor: CalciteTheme.palette.darkRed200,
-  trackActiveBgcolor: CalciteTheme.palette.gray,
-  trackErrorActiveBgcolor: CalciteTheme.palette.darkRed,
+  trackHoverBgcolor: theme.palette.lightGray,
+  trackErrorHoverBgcolor: theme.palette.darkRed200,
+  trackActiveBgcolor: theme.palette.gray,
+  trackErrorActiveBgcolor: theme.palette.darkRed,
   thumbHeight: '18px',
   thumbWidth: '18px',
   thumbBorder: '2px solid',
-  thumbBorderColor: CalciteTheme.palette.gray,
-  thumbErrorBorderColor: CalciteTheme.palette.darkRed200,
-  thumbBorderHoverColor: CalciteTheme.palette.Brand_Blue_200,
-  thumbErrorBorderHoverColor: CalciteTheme.palette.darkRed200,
+  thumbBorderColor: theme.palette.gray,
+  thumbErrorBorderColor: theme.palette.darkRed200,
+  thumbBorderHoverColor: theme.palette.Brand_Blue_200,
+  thumbErrorBorderHoverColor: theme.palette.darkRed200,
   thumbShadowHover: `0 0 4px 1px ${transparentize(
     0.1,
-    CalciteTheme.palette.lighterGray
+    theme.palette.lighterGray
   )}`,
   thumbShadowActive: `0 0 4px 1px ${transparentize(
     0.1,
-    CalciteTheme.palette.lightestGray
+    theme.palette.lightestGray
   )}`,
-  thumbBgDefault: CalciteTheme.palette.white,
-  thumbBgHover: CalciteTheme.palette.Brand_Blue_200,
-  thumbErrorBgHover: CalciteTheme.palette.darkRed200,
+  thumbBgDefault: theme.palette.white,
+  thumbBgHover: theme.palette.Brand_Blue_200,
+  thumbErrorBgHover: theme.palette.darkRed200,
   thumbBgActive: EsriColors.Calcite_Blue_a250,
-  thumbErrorBgActive: CalciteTheme.palette.darkRed
+  thumbErrorBgActive: theme.palette.darkRed
 };
 
 const rangeStyle = () => {
@@ -353,5 +354,6 @@ const StyledSlider = styled(CalciteInput)`
     }
   }
 `;
+StyledSlider.defaultProps = { theme };
 
 export { StyledSlider };

--- a/src/Slider/Slider-styled.js
+++ b/src/Slider/Slider-styled.js
@@ -9,13 +9,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.​
 
+// styled-components
 import styled, { css } from 'styled-components';
-import { transparentize } from 'polished';
 
-// Calcite theme
+// Utils, common elements
+import { CalciteInput } from '../utils/commonElements';
+
+// Calcite theme and Esri colors
 import { CalciteTheme as theme, EsriColors } from '../CalciteThemeProvider';
 
-import { CalciteInput } from '../utils/commonElements';
+// Calcite components
+
+// Icons
+
+// Third party libraries
+import { transparentize } from 'polished';
 
 const rangeProps = {
   rangeBorder: '1px solid transparent',

--- a/src/Stepper/Stepper-styled.js
+++ b/src/Stepper/Stepper-styled.js
@@ -11,8 +11,11 @@
 
 import styled, { css } from 'styled-components';
 import { CalciteH6, CalciteP } from '../Elements';
+
+// Calcite theme
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
 import { fontSize, unitCalc } from '../utils/helpers';
-import { CalciteTheme } from '../CalciteThemeProvider';
 
 const StyledStepper = styled.div`
   display: flex;
@@ -23,6 +26,7 @@ const StyledStepper = styled.div`
       flex-direction: column;
     `};
 `;
+StyledStepper.defaultProps = { theme };
 
 const StyledStep = styled.div`
   display: flex;
@@ -60,6 +64,7 @@ const StyledStep = styled.div`
       }
     `};
 `;
+StyledStep.defaultProps = { theme };
 
 const StyledStepTextContainer = styled.div`
   display: flex;
@@ -68,6 +73,7 @@ const StyledStepTextContainer = styled.div`
   flex: 1 0 34px;
   align-items: flex-start;
 `;
+StyledStepTextContainer.defaultProps = { theme };
 
 const StyledStepTitle = styled(CalciteH6)`
   margin: 0;
@@ -137,6 +143,7 @@ const StyledStepTitle = styled(CalciteH6)`
       }
     `};
 `;
+StyledStepTitle.defaultProps = { theme };
 
 const StyledStepDescription = styled(CalciteP)`
   ${fontSize(-2)};
@@ -168,6 +175,7 @@ const StyledStepDescription = styled(CalciteP)`
       color: ${props => props.theme.palette.red};
     `};
 `;
+StyledStepDescription.defaultProps = { theme };
 
 const StyledStepIcon = styled.div`
   position: relative;
@@ -205,31 +213,32 @@ const StyledStepIcon = styled.div`
       }
     `};
 `;
+StyledStepIcon.defaultProps = { theme };
 
 const StepAvatarStyles = {
   default: {
     width: 30,
     height: 30,
-    color: CalciteTheme.palette.lightGray,
+    color: theme.palette.lightGray,
     backgroundColor: 'transparent',
     fontWeight: 300,
-    border: `1px solid ${CalciteTheme.palette.lighterGray}`
+    border: `1px solid ${theme.palette.lighterGray}`
   },
   active: {
-    backgroundColor: CalciteTheme.palette.blue,
-    color: CalciteTheme.palette.white,
+    backgroundColor: theme.palette.blue,
+    color: theme.palette.white,
     fontWeight: 400,
-    borderColor: CalciteTheme.palette.blue
+    borderColor: theme.palette.blue
   },
   complete: {
-    color: CalciteTheme.palette.blue,
+    color: theme.palette.blue,
     backgroundColor: 'transparent',
-    borderColor: CalciteTheme.palette.blue
+    borderColor: theme.palette.blue
   },
   error: {
-    color: CalciteTheme.palette.red,
+    color: theme.palette.red,
     backgroundColor: 'transparent',
-    borderColor: CalciteTheme.palette.red
+    borderColor: theme.palette.red
   },
   small: {
     width: 22,
@@ -242,16 +251,16 @@ const StepCustomIconStyles = {
   default: {
     width: 30,
     height: 30,
-    fill: CalciteTheme.palette.lightGray
+    fill: theme.palette.lightGray
   },
   active: {
-    fill: CalciteTheme.palette.blue
+    fill: theme.palette.blue
   },
   complete: {
-    fill: CalciteTheme.palette.blue
+    fill: theme.palette.blue
   },
   error: {
-    fill: CalciteTheme.palette.red
+    fill: theme.palette.red
   },
   small: {
     width: 22,
@@ -261,7 +270,7 @@ const StepCustomIconStyles = {
 };
 
 const StepCompleteIconStyles = {
-  fill: CalciteTheme.palette.blue
+  fill: theme.palette.blue
 };
 
 const StepIconStyle = {

--- a/src/Stepper/Stepper-styled.js
+++ b/src/Stepper/Stepper-styled.js
@@ -9,13 +9,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.​
 
+// styled-components
 import styled, { css } from 'styled-components';
-import { CalciteH6, CalciteP } from '../Elements';
 
-// Calcite theme
+// Utils, common elements
+import { fontSize, unitCalc } from '../utils/helpers';
+
+// Calcite theme and Esri colors
 import { CalciteTheme as theme } from '../CalciteThemeProvider';
 
-import { fontSize, unitCalc } from '../utils/helpers';
+// Calcite components
+import { CalciteH6, CalciteP } from '../Elements';
+
+// Icons
+
+// Third party libraries
 
 const StyledStepper = styled.div`
   display: flex;

--- a/src/SubNav/SubNav-styled.js
+++ b/src/SubNav/SubNav-styled.js
@@ -11,6 +11,10 @@
 
 import styled, { css } from 'styled-components';
 import { CalciteA, CalciteH1 } from '../Elements';
+
+// Calcite theme
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
 import {
   subNavUnderline,
   unitCalc,
@@ -42,6 +46,7 @@ const StyledSubNav = styled.header`
       )};
     `};
 `;
+StyledSubNav.defaultProps = { theme };
 
 const StyledSubNavLeftContent = styled.div`
   display: flex;
@@ -49,6 +54,7 @@ const StyledSubNavLeftContent = styled.div`
   justify-content: space-between;
   flex-direction: column;
 `;
+StyledSubNavLeftContent.defaultProps = { theme };
 
 const StyledSubNavLink = styled(CalciteA)`
   padding: 0.25em 0.75em;
@@ -92,6 +98,7 @@ const StyledSubNavLink = styled(CalciteA)`
       pointer-events: none;
     `};
 `;
+StyledSubNavLink.defaultProps = { theme };
 
 const StyledSubNavList = styled.nav`
   display: flex;
@@ -100,6 +107,7 @@ const StyledSubNavList = styled.nav`
   padding-left: 0.25em;
   box-sizing: border-box;
 `;
+StyledSubNavList.defaultProps = { theme };
 
 const StyledSubNavActions = styled.nav`
   margin: 0.5em;
@@ -107,6 +115,7 @@ const StyledSubNavActions = styled.nav`
   justify-content: flex-end;
   align-items: center;
 `;
+StyledSubNavActions.defaultProps = { theme };
 
 const StyledSubNavTitle = styled(CalciteH1)`
   ${fontSize(4)};
@@ -122,11 +131,13 @@ const StyledSubNavTitle = styled(CalciteH1)`
       color: ${props.theme.palette.white};
     `};
 `;
+StyledSubNavTitle.defaultProps = { theme };
 
 const StyledMultiRowActions = styled.div`
   display: flex;
   flex-direction: column;
 `;
+StyledMultiRowActions.defaultProps = { theme };
 
 export {
   StyledSubNav,

--- a/src/SubNav/SubNav-styled.js
+++ b/src/SubNav/SubNav-styled.js
@@ -9,11 +9,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.​
 
+// styled-components
 import styled, { css } from 'styled-components';
+
+// Utils, common elements
+
+// Calcite theme and Esri colors
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
+// Calcite components
 import { CalciteA, CalciteH1 } from '../Elements';
 
-// Calcite theme
-import { CalciteTheme as theme } from '../CalciteThemeProvider';
+// Icons
+
+// Third party libraries
 
 import {
   subNavUnderline,
@@ -122,7 +131,7 @@ const StyledSubNavTitle = styled(CalciteH1)`
   padding-left: 0.25em;
   margin-top: ${props => unitCalc(props.theme.baseline, 2, '/')};
   margin-bottom: ${props => unitCalc(props.theme.baseline, 2, '/')};
-  line-height: 1.25
+  line-height: 1.25;
   box-sizing: border-box;
 
   ${props =>

--- a/src/Switch/Switch-styled.js
+++ b/src/Switch/Switch-styled.js
@@ -12,10 +12,10 @@
 import styled, { css } from 'styled-components';
 import { transparentize } from 'polished';
 
-import { CalciteTheme, EsriColors } from '../CalciteThemeProvider';
+// Calcite theme
+import { CalciteTheme as theme, EsriColors } from '../CalciteThemeProvider';
 
 import { baseRadioCheckbox } from '../utils/commonElements';
-
 import { fontSize, unitCalc } from '../utils/helpers';
 
 const switchProps = {
@@ -25,8 +25,8 @@ const switchProps = {
   switchBorderColor: EsriColors.Calcite_Gray_350,
   switchHoverBg: EsriColors.Calcite_Gray_250,
   switchHoverBorderColor: EsriColors.Calcite_Gray_350,
-  switchCheckedBg: CalciteTheme.palette.blue,
-  switchCheckedBorderColor: CalciteTheme.palette.darkBlue,
+  switchCheckedBg: theme.palette.blue,
+  switchCheckedBorderColor: theme.palette.darkBlue,
   switchFocusShadow: `0 0 4px 2px ${transparentize(
     0.1,
     EsriColors.Calcite_Gray_350
@@ -43,18 +43,18 @@ const switchProps = {
   handleTopDistance: '-1px',
   handleEdgeDistance: '-1px',
   handleActiveEdgeDistance: '1px',
-  handleBg: CalciteTheme.palette.white,
+  handleBg: theme.palette.white,
   handleBorderColor: EsriColors.Calcite_Gray_450,
   handleShadow: `0 1px 1px 0px ${transparentize(
     0.8,
-    CalciteTheme.palette.darkestGray
+    theme.palette.darkestGray
   )}`,
   handleHoverBorderColor: EsriColors.Calcite_Blue_a200,
   handleHoverShadow: `0 1px 2px 0px ${transparentize(
     0.8,
-    CalciteTheme.palette.darkestGray
+    theme.palette.darkestGray
   )}`,
-  handleCheckedBorderColor: CalciteTheme.palette.darkBlue,
+  handleCheckedBorderColor: theme.palette.darkBlue,
   handleCheckedShadow: `0 2px 1px 0px {transparentize(.8,CalciteTheme.palette.darkestGray)}`,
   handleActiveShadow: `0 3px 1px 0px {transparentize(.8,CalciteTheme.palette.darkestGray)}`,
   switchDestructiveCheckedBg: EsriColors.Calcite_Red_a200,
@@ -71,6 +71,7 @@ const StyledSwitch = styled.label`
   tap-highlight-color: transparent;
   margin: 0 0 ${props => props.theme.baseline} 0;
 `;
+StyledSwitch.defaultProps = { theme };
 
 const StyledSwitchInput = styled(baseRadioCheckbox)`
   opacity: 0;
@@ -79,6 +80,7 @@ const StyledSwitchInput = styled(baseRadioCheckbox)`
   margin: 0;
   position: absolute;
 `;
+StyledSwitchInput.defaultProps = { theme };
 
 const StyledSwitchTrack = styled.span`
   position: relative;
@@ -233,6 +235,7 @@ const StyledSwitchTrack = styled.span`
     }
   }
 `;
+StyledSwitchTrack.defaultProps = { theme };
 
 const StyledSwitchLabel = styled.span`
   ${fontSize(-1)};
@@ -244,6 +247,7 @@ const StyledSwitchLabel = styled.span`
     margin-right: 1rem;
   }
 `;
+StyledSwitchLabel.defaultProps = { theme };
 
 export {
   StyledSwitch,

--- a/src/Switch/Switch-styled.js
+++ b/src/Switch/Switch-styled.js
@@ -9,14 +9,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.​
 
+// styled-components
 import styled, { css } from 'styled-components';
-import { transparentize } from 'polished';
 
-// Calcite theme
+// Utils, common elements
+import { fontSize, unitCalc } from '../utils/helpers';
+import { baseRadioCheckbox } from '../utils/commonElements';
+
+// Calcite theme and Esri colors
 import { CalciteTheme as theme, EsriColors } from '../CalciteThemeProvider';
 
-import { baseRadioCheckbox } from '../utils/commonElements';
-import { fontSize, unitCalc } from '../utils/helpers';
+// Calcite components
+
+// Icons
+
+// Third party libraries
+import { transparentize } from 'polished';
 
 const switchProps = {
   switchWidth: '36px',

--- a/src/Table/Table-styled.js
+++ b/src/Table/Table-styled.js
@@ -9,13 +9,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.​
 
+// styled-components
 import styled, { css } from 'styled-components';
 
-// Calcite theme
+// Utils, common elements
+import { fontSize, unitCalc } from '../utils/helpers';
+
+// Calcite theme and Esri colors
 import { CalciteTheme as theme } from '../CalciteThemeProvider';
 
-import { unitCalc } from '../utils/helpers';
-import { fontSize } from '../utils/helpers';
+// Calcite components
+
+// Icons
+
+// Third party libraries
 
 const StyledTable = styled.table`
   width: 100%;

--- a/src/Table/Table-styled.js
+++ b/src/Table/Table-styled.js
@@ -10,6 +10,10 @@
 // limitations under the License.​
 
 import styled, { css } from 'styled-components';
+
+// Calcite theme
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
 import { unitCalc } from '../utils/helpers';
 import { fontSize } from '../utils/helpers';
 
@@ -62,6 +66,7 @@ const StyledTable = styled.table`
       border-bottom: none;
     `};
 `;
+StyledTable.defaultProps = { theme };
 
 const StyledTableBody = styled.tbody`
   overflow: auto;
@@ -91,6 +96,7 @@ const StyledTableBody = styled.tbody`
       border-bottom: none;
     `};
 `;
+StyledTableBody.defaultProps = { theme };
 
 const StyledTableCell = styled.td`
   font-weight: 300;
@@ -162,6 +168,7 @@ const StyledTableCell = styled.td`
       }
     `};
 `;
+StyledTableCell.defaultProps = { theme };
 
 const StyledTableHeader = styled.thead`
   background-color: ${props => props.theme.palette.lightestGray};
@@ -209,6 +216,7 @@ const StyledTableHeader = styled.thead`
       border-bottom: none;
     `};
 `;
+StyledTableHeader.defaultProps = { theme };
 
 const StyledTableHeaderCell = styled.th`
   font-weight: 300;
@@ -261,6 +269,7 @@ const StyledTableHeaderCell = styled.th`
       }
     `};
 `;
+StyledTableHeaderCell.defaultProps = { theme };
 
 const StyledTableHeaderRow = styled.tr`
   ${props =>
@@ -272,6 +281,7 @@ const StyledTableHeaderRow = styled.tr`
       }
     `};
 `;
+StyledTableHeaderRow.defaultProps = { theme };
 
 const StyledTableRow = styled.tr`
   border-bottom: 1px solid ${props => props.theme.palette.lighterGray};
@@ -333,6 +343,7 @@ const StyledTableRow = styled.tr`
       border-bottom: none;
     `};
 `;
+StyledTableRow.defaultProps = { theme };
 
 export {
   StyledTable,

--- a/src/Tabs/Tab-styled.js
+++ b/src/Tabs/Tab-styled.js
@@ -9,12 +9,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.​
 
+// styled-components
 import styled, { css } from 'styled-components';
+
+// Utils, common elements
 import { fontSize, unitCalc, transition } from '../utils/helpers';
+
+// Calcite theme and Esri colors
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
+// Calcite components
 import { CalciteA } from '../Elements';
 
-// Calcite theme
-import { CalciteTheme as theme } from '../CalciteThemeProvider';
+// Icons
+
+// Third party libraries
 
 const StyledTab = styled.div`
   padding: 0;

--- a/src/Tabs/Tab-styled.js
+++ b/src/Tabs/Tab-styled.js
@@ -13,6 +13,9 @@ import styled, { css } from 'styled-components';
 import { fontSize, unitCalc, transition } from '../utils/helpers';
 import { CalciteA } from '../Elements';
 
+// Calcite theme
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
 const StyledTab = styled.div`
   padding: 0;
   flex: 1 0 auto;
@@ -23,6 +26,7 @@ const StyledTab = styled.div`
       float: right;
     `};
 `;
+StyledTab.defaultProps = { theme };
 
 const StyledTabTitle = styled(CalciteA)`
   box-sizing: border-box;
@@ -188,6 +192,7 @@ const StyledTabTitle = styled(CalciteA)`
       pointer-events: none;
     `};
 `;
+StyledTabTitle.defaultProps = { theme };
 
 const StyledTabNav = styled.nav`
   display: flex;
@@ -198,6 +203,7 @@ const StyledTabNav = styled.nav`
     clear: both;
   }
 `;
+StyledTabNav.defaultProps = { theme };
 
 const StyledTabContents = styled.div`
   box-sizing: border-box;
@@ -226,6 +232,7 @@ const StyledTabContents = styled.div`
       border: none;
     `};
 `;
+StyledTabContents.defaultProps = { theme };
 
 const StyledTabSection = styled.article`
   box-sizing: border-box;
@@ -271,6 +278,7 @@ const StyledTabSection = styled.article`
       color: ${props => props.theme.palette.white};
     `};
 `;
+StyledTabSection.defaultProps = { theme };
 
 export {
   StyledTab,

--- a/src/TextField/TextField-styled.js
+++ b/src/TextField/TextField-styled.js
@@ -11,6 +11,10 @@
 
 import styled, { css } from 'styled-components';
 import { CalciteInput, CalciteTextarea } from '../utils/commonElements';
+
+// Calcite theme
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
 import { unitCalc } from '../utils/helpers';
 
 const StyledTextField = styled(CalciteInput)`
@@ -30,6 +34,7 @@ const StyledTextField = styled(CalciteInput)`
       border-bottom-right-radius: 0;
     `};
 `;
+StyledTextField.defaultProps = { theme };
 
 const StyledTextArea = styled(CalciteTextarea)`
   ${props =>
@@ -48,6 +53,7 @@ const StyledTextArea = styled(CalciteTextarea)`
       border-bottom-right-radius: 0;
     `};
 `;
+StyledTextArea.defaultProps = { theme };
 
 const StyledTextFieldAdornmentWrapper = styled.div`
   display: flex;
@@ -58,6 +64,7 @@ const StyledTextFieldAdornmentWrapper = styled.div`
       width: 100%;
     `};
 `;
+StyledTextFieldAdornmentWrapper.defaultProps = { theme };
 
 const StyledAdornmentWrapper = styled.div`
   display: flex;
@@ -100,6 +107,7 @@ const StyledAdornmentWrapper = styled.div`
       border-bottom-left-radius: 0;
     `};
 `;
+StyledAdornmentWrapper.defaultProps = { theme };
 
 export {
   StyledTextField,

--- a/src/TextField/TextField-styled.js
+++ b/src/TextField/TextField-styled.js
@@ -9,13 +9,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.​
 
+// styled-components
 import styled, { css } from 'styled-components';
+
+// Utils, common elements
+import { unitCalc } from '../utils/helpers';
 import { CalciteInput, CalciteTextarea } from '../utils/commonElements';
 
-// Calcite theme
+// Calcite theme and Esri colors
 import { CalciteTheme as theme } from '../CalciteThemeProvider';
 
-import { unitCalc } from '../utils/helpers';
+// Calcite components
+
+// Icons
+
+// Third party libraries
 
 const StyledTextField = styled(CalciteInput)`
   ${props =>

--- a/src/Toaster/Toaster-styled.js
+++ b/src/Toaster/Toaster-styled.js
@@ -13,6 +13,9 @@ import styled from 'styled-components';
 
 import Button from '../Button';
 
+// Calcite theme
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
 const StyledCloseButton = styled(Button)`
   color: currentColor;
 
@@ -21,5 +24,6 @@ const StyledCloseButton = styled(Button)`
     opacity: 0.7;
   }
 `;
+StyledCloseButton.defaultProps = { theme };
 
 export { StyledCloseButton };

--- a/src/Toaster/Toaster-styled.js
+++ b/src/Toaster/Toaster-styled.js
@@ -9,12 +9,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.​
 
+// styled-components
 import styled from 'styled-components';
 
+// Utils, common elements
+
+// Calcite theme and Esri colors
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
+// Calcite components
 import Button from '../Button';
 
-// Calcite theme
-import { CalciteTheme as theme } from '../CalciteThemeProvider';
+// Icons
+
+// Third party libraries
 
 const StyledCloseButton = styled(Button)`
   color: currentColor;

--- a/src/Tooltip/Tooltip-styled.js
+++ b/src/Tooltip/Tooltip-styled.js
@@ -10,11 +10,16 @@
 // limitations under the License.​
 
 import styled, { css } from 'styled-components';
+
+// Calcite theme
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
 import { unitCalc, fontSize } from '../utils/helpers';
 
 const StyledTargetWrapper = styled.div`
   display: inline-block;
 `;
+StyledTargetWrapper.defaultProps = { theme };
 
 const StyledTooltip = styled.div`
   padding: ${props => unitCalc(props.theme.baseline, 4, '/')}
@@ -60,6 +65,7 @@ const StyledTooltip = styled.div`
       opacity: 1;
     `};
 `;
+StyledTooltip.defaultProps = { theme };
 
 const StyledTooltipArrow = styled.div`
   width: 0;
@@ -93,5 +99,6 @@ const StyledTooltipArrow = styled.div`
     right: -5px;
   }
 `;
+StyledTooltipArrow.defaultProps = { theme };
 
 export { StyledTargetWrapper, StyledTooltip, StyledTooltipArrow };

--- a/src/Tooltip/Tooltip-styled.js
+++ b/src/Tooltip/Tooltip-styled.js
@@ -9,12 +9,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.​
 
+// styled-components
 import styled, { css } from 'styled-components';
 
-// Calcite theme
+// Utils, common elements
+import { unitCalc, fontSize } from '../utils/helpers';
+
+// Calcite theme and Esri colors
 import { CalciteTheme as theme } from '../CalciteThemeProvider';
 
-import { unitCalc, fontSize } from '../utils/helpers';
+// Calcite components
+
+// Icons
+
+// Third party libraries
 
 const StyledTargetWrapper = styled.div`
   display: inline-block;

--- a/src/TopNav/TopNav-styled.js
+++ b/src/TopNav/TopNav-styled.js
@@ -9,13 +9,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.​
 
+// styled-components
 import styled, { css } from 'styled-components';
-import { CalciteA } from '../Elements';
 
-// Calcite theme
+// Utils, common elements
+import { clearfix, fontSize } from '../utils/helpers';
+
+// Calcite theme and Esri colors
 import { CalciteTheme as theme } from '../CalciteThemeProvider';
 
-import { clearfix, fontSize } from '../utils/helpers';
+// Calcite components
+import { CalciteA } from '../Elements';
+
+// Icons
+
+// Third party libraries
 
 const StyledTopNav = styled.header`
   display: flex;

--- a/src/TopNav/TopNav-styled.js
+++ b/src/TopNav/TopNav-styled.js
@@ -10,8 +10,12 @@
 // limitations under the License.​
 
 import styled, { css } from 'styled-components';
-import { clearfix, fontSize } from '../utils/helpers';
 import { CalciteA } from '../Elements';
+
+// Calcite theme
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
+import { clearfix, fontSize } from '../utils/helpers';
 
 const StyledTopNav = styled.header`
   display: flex;
@@ -22,6 +26,7 @@ const StyledTopNav = styled.header`
   z-index: 100;
   ${clearfix()};
 `;
+StyledTopNav.defaultProps = { theme };
 
 const StyledTopNavActions = styled.div`
   display: flex;
@@ -37,6 +42,7 @@ const StyledTopNavActions = styled.div`
     }
   }
 `;
+StyledTopNavActions.defaultProps = { theme };
 
 const StyledTopNavBrandLink = styled.a`
   padding: 0 ${props => props.theme.baseline};
@@ -44,10 +50,12 @@ const StyledTopNavBrandLink = styled.a`
   align-items: center;
   text-decoration: none;
 `;
+StyledTopNavBrandLink.defaultProps = { theme };
 
 const StyledTopNavBrandImg = styled.img`
   height: 30px;
 `;
+StyledTopNavBrandImg.defaultProps = { theme };
 
 const StyledTopNavLink = styled(CalciteA)`
   ${fontSize(0)};
@@ -85,6 +93,7 @@ const StyledTopNavLink = styled(CalciteA)`
     border-bottom-color: ${props => props.theme.palette.blue};
   }
 `;
+StyledTopNavLink.defaultProps = { theme };
 
 const StyledTopNavList = styled.nav`
   padding: 0;
@@ -97,6 +106,7 @@ const StyledTopNavList = styled.nav`
       float: right;
     `};
 `;
+StyledTopNavList.defaultProps = { theme };
 
 const StyledTopNavTitle = styled(CalciteA)`
   margin-right: 1.5rem;
@@ -109,6 +119,7 @@ const StyledTopNavTitle = styled(CalciteA)`
     text-decoration: none;
   }
 `;
+StyledTopNavTitle.defaultProps = { theme };
 
 export {
   StyledTopNav,

--- a/src/utils/commonElements.js
+++ b/src/utils/commonElements.js
@@ -9,12 +9,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.​
 
+// styled-components
 import styled, { css } from 'styled-components';
 
-// Calcite theme
+// Utils
+import { fontSize, unitCalc, transition } from './helpers';
+
+// Calcite theme and Esri colors
 import { CalciteTheme as theme } from '../CalciteThemeProvider';
 
-import { fontSize, unitCalc, transition } from './helpers';
+// Calcite components
+
+// Icons
+
+// Third party libraries
 
 const formSelectInputTextarea = styled.select`
   position: relative;

--- a/src/utils/commonElements.js
+++ b/src/utils/commonElements.js
@@ -10,6 +10,10 @@
 // limitations under the License.​
 
 import styled, { css } from 'styled-components';
+
+// Calcite theme
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
+
 import { fontSize, unitCalc, transition } from './helpers';
 
 const formSelectInputTextarea = styled.select`
@@ -43,6 +47,7 @@ const formSelectInputTextarea = styled.select`
       0 0 5px rgba(81, 167, 232, 0.5);
   }
 `;
+formSelectInputTextarea.defaultProps = { theme };
 
 const select = styled(formSelectInputTextarea)`
   background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjwhLS0gR2VuZXJhdG9yOiBBZG9iZSBJbGx1c3RyYXRvciAxNi4wLjQsIFNWRyBFeHBvcnQgUGx1Zy1JbiAuIFNWRyBWZXJzaW9uOiA2LjAwIEJ1aWxkIDApICAtLT4NCjwhRE9DVFlQRSBzdmcgUFVCTElDICItLy9XM0MvL0RURCBTVkcgMS4xLy9FTiIgImh0dHA6Ly93d3cudzMub3JnL0dyYXBoaWNzL1NWRy8xLjEvRFREL3N2ZzExLmR0ZCI+DQo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4Ig0KCSB3aWR0aD0iMTAwcHgiIGhlaWdodD0iMTAwcHgiIHZpZXdCb3g9IjAgMCAxMDAgMTAwIiBlbmFibGUtYmFja2dyb3VuZD0ibmV3IDAgMCAxMDAgMTAwIiB4bWw6c3BhY2U9InByZXNlcnZlIj4NCjxnPg0KCTxwYXRoIGZpbGw9IiM1OTU5NTkiIGQ9Ik03NS43NDksMzcuNDY2YzAuNDI1LDAuNDI1LDAuNTUyLDEuMDYzLDAuMzIyLDEuNjE4Qzc1Ljg0MSwzOS42MzksNzUuMzAxLDQwLDc0LjY5OSw0MGgtNDkuNA0KCQljLTAuNiwwLTEuMTQzLTAuMzYyLTEuMzcyLTAuOTE3Yy0wLjIzLTAuNTU1LTAuMTAzLTEuMTkzLDAuMzIyLTEuNjE4bDIzLjQ0LTIzLjQ0YzEuMjc2LTEuMjc2LDMuMzQzLTEuMjc2LDQuNjIsMEw3NS43NDksMzcuNDY2DQoJCUw3NS43NDksMzcuNDY2eiBNMjQuMjUsNjIuNTM0Yy0wLjQyNi0wLjQyNS0wLjU1My0xLjA2My0wLjMyMy0xLjYxOGMwLjIzLTAuNTU1LDAuNzctMC45MTYsMS4zNy0wLjkxNkg3NC43DQoJCWMwLjYwMiwwLDEuMTQzLDAuMzU5LDEuMzczLDAuOTE2YzAuMjMsMC41NTUsMC4xMDMsMS4xOTMtMC4zMjIsMS42MThMNTIuMzEsODUuOTc3Yy0xLjI3NSwxLjI3NS0zLjM0NCwxLjI3NC00LjYyLDBMMjQuMjUsNjIuNTM0eg0KCQkiLz4NCjwvZz4NCjwvc3ZnPg0K');
@@ -125,6 +130,7 @@ const select = styled(formSelectInputTextarea)`
     }
   }
 `;
+select.defaultProps = { theme };
 
 const input = styled(formSelectInputTextarea)`
   -webkit-appearance: none;
@@ -191,6 +197,7 @@ const input = styled(formSelectInputTextarea)`
     height: auto;
   }
 `;
+input.defaultProps = { theme };
 
 const fieldset = styled.fieldset`
   label {
@@ -200,6 +207,7 @@ const fieldset = styled.fieldset`
     width: auto;
   }
 `;
+fieldset.defaultProps = { theme };
 
 const textarea = styled(formSelectInputTextarea)`
   height: auto;
@@ -211,6 +219,7 @@ const textarea = styled(formSelectInputTextarea)`
       width: 100%;
     `};
 `;
+textarea.defaultProps = { theme };
 
 const baseRadioCheckbox = styled.input`
   float: left;
@@ -230,6 +239,7 @@ const baseRadioCheckbox = styled.input`
     outline: auto -webkit-focus-ring-color;
   }
 `;
+baseRadioCheckbox.defaultProps = { theme };
 
 export {
   select as CalciteSelect,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I used [this regex](regexr.com/4j663) to find all declarations of a styled-component within each component's `*-styled.js` file as well as commonElements.js and used `$&$1.defaultProps = { theme };\n` to add the theme to each declaration.
This also involved importing `CalciteTheme` as `theme` for each module, and I refactored any instances where `CalciteTheme` was already being imported and consumed.

Following this I standardized import orders and categorized them, and made an example snippet in `CONTRIBUTING.md` for any newly created styled-component modules.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#286 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Allows users to avoid completely breaking errors when using calcite-react components when being used outside of a `<CalciteThemeProvider/>`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Removed the global `<CalciteThemeProvider/>` wrapper in docz to see if a palette is undefined error would be thrown as well as checking for visual changes.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
