### PR TITLE
FormHelperText height => min-height

### DIFF
--- a/src/Form/Form-styled.js
+++ b/src/Form/Form-styled.js
@@ -85,7 +85,7 @@ const StyledFormControlLabelText = styled.span`
 const StyledFormHelperText = styled.span`
   ${fontSize(-3)};
   color: ${props => props.theme.palette.transparentBlack};
-  height: 1.55rem;
+  min-height: 1.55em;
   margin-bottom: -1.55rem;
 
   ${props =>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Changes the `height: 1.55em` rule on StyledFormHelperText to `min-height: 1.55em` to allow for auto-sizing.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#295 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Visual bugs with overflowing FormHelperText content

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Visually checked Form documentation page.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
