### PR TITLE
Add Tooltip enterDelay to CalciteTheme

### DIFF
--- a/docz/GuideExample.js
+++ b/docz/GuideExample.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import { CalciteTheme as theme } from '../src/CalciteThemeProvider';
 
 const GuideExampleContainer = styled.div`
   padding: 1rem;
@@ -20,6 +21,7 @@ const GuideExampleContainer = styled.div`
     border-bottom-left-radius: 6px;
   }
 `;
+GuideExampleContainer.defaultProps = { theme };
 
 const GuideExampleLabel = styled.code`
   color: ${props => props.theme.palette.darkestGray};
@@ -39,6 +41,7 @@ const GuideExampleLabel = styled.code`
     border-radius: 0 3px 0 3px;
   }
 `;
+GuideExampleLabel.defaultProps = { theme };
 
 const GuideExample = ({ children, label, style, ...other }) => {
   function _getLabel() {

--- a/src/CalciteThemeProvider/CalciteTheme.js
+++ b/src/CalciteThemeProvider/CalciteTheme.js
@@ -129,9 +129,10 @@ const CalciteTheme = {
   boxShadow: '0 0 16px 0 rgba(0,0,0,.05)',
   drawerWidth: '280px',
   borderRadius: 0,
+  tooltipEnterDelay: 0,
 
   // ┌─────────────┐
-  // │ TYPE COLORS │
+  // │ Type Colors │
   // └─────────────┘
   typeColor: EsriColors.Calcite_Gray_650,
   linkColor: EsriColors.Calcite_Highlight_Blue_350,
@@ -164,7 +165,7 @@ const CalciteTheme = {
   columnGutterFallback: '20px',
   containerWidthFallback: '960px',
 
-  // Medium
+  // Large
   largeClass: 'large',
   largeColumnCount: '24',
 

--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -153,7 +153,7 @@ Tooltip.propTypes = {
   positionFixed: PropTypes.bool,
   /** Duration of animation in milliseconds. */
   transitionDuration: PropTypes.number,
-  /** Delay (in milliseconds) before the Tooltip will show. */
+  /** Delay (in milliseconds) before the Tooltip will show. Prop overrides the value specified in the theme. */
   enterDelay: PropTypes.number,
   /** Apply styles to the Tooltip element. */
   style: PropTypes.object,

--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -16,6 +16,8 @@ import PropTypes from 'prop-types';
 import { Manager, Reference, Popper } from 'react-popper';
 import { ThemeContext } from 'styled-components';
 
+import { CalciteTheme } from '../CalciteThemeProvider';
+
 import {
   StyledTargetWrapper,
   StyledTooltip,
@@ -69,7 +71,7 @@ class Tooltip extends Component {
 
     return (
       <ThemeContext.Consumer>
-        {theme => (
+        {(theme = CalciteTheme) => (
           <Manager>
             <Reference style={{ display: 'inline-block' }}>
               {({ ref }) => (

--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -14,6 +14,7 @@ import ReactDOM from 'react-dom';
 import Transition from 'react-transition-group/Transition';
 import PropTypes from 'prop-types';
 import { Manager, Reference, Popper } from 'react-popper';
+import { withTheme } from 'styled-components';
 
 import {
   StyledTargetWrapper,
@@ -80,7 +81,14 @@ class Tooltip extends Component {
             </StyledTargetWrapper>
           )}
         </Reference>
-        <Transition in={isOpen} timeout={enterDelay}>
+        <Transition
+          in={isOpen}
+          timeout={
+            enterDelay !== undefined
+              ? enterDelay
+              : this.props.theme.tooltipEnterDelay
+          }
+        >
           {state => {
             return isOpen
               ? this._getPopper(
@@ -156,10 +164,9 @@ Tooltip.propTypes = {
 Tooltip.defaultProps = {
   title: '',
   placement: undefined,
-  transitionDuration: 200,
-  enterDelay: 0
+  transitionDuration: 200
 };
 
 Tooltip.displayName = 'Tooltip';
 
-export default Tooltip;
+export default withTheme(Tooltip);

--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -14,7 +14,7 @@ import ReactDOM from 'react-dom';
 import Transition from 'react-transition-group/Transition';
 import PropTypes from 'prop-types';
 import { Manager, Reference, Popper } from 'react-popper';
-import { withTheme } from 'styled-components';
+import { ThemeContext } from 'styled-components';
 
 import {
   StyledTargetWrapper,
@@ -68,71 +68,73 @@ class Tooltip extends Component {
     const usePreventOverflow = appendToBody || positionFixed ? false : true;
 
     return (
-      <Manager>
-        <Reference style={{ display: 'inline-block' }}>
-          {({ ref }) => (
-            <StyledTargetWrapper
-              ref={ref}
-              style={targetWrapperStyle}
-              onMouseEnter={this._handleReferenceEnter}
-              onMouseLeave={this._handleReferenceLeave}
+      <ThemeContext.Consumer>
+        {theme => (
+          <Manager>
+            <Reference style={{ display: 'inline-block' }}>
+              {({ ref }) => (
+                <StyledTargetWrapper
+                  ref={ref}
+                  style={targetWrapperStyle}
+                  onMouseEnter={this._handleReferenceEnter}
+                  onMouseLeave={this._handleReferenceLeave}
+                >
+                  {children}
+                </StyledTargetWrapper>
+              )}
+            </Reference>
+            <Transition
+              in={isOpen}
+              timeout={
+                enterDelay !== undefined ? enterDelay : theme.tooltipEnterDelay
+              }
             >
-              {children}
-            </StyledTargetWrapper>
-          )}
-        </Reference>
-        <Transition
-          in={isOpen}
-          timeout={
-            enterDelay !== undefined
-              ? enterDelay
-              : this.props.theme.tooltipEnterDelay
-          }
-        >
-          {state => {
-            return isOpen
-              ? this._getPopper(
-                  <Popper
-                    positionFixed={positionFixed}
-                    placement={placement}
-                    modifiers={{
-                      preventOverflow: {
-                        enabled: usePreventOverflow
-                      },
-                      hide: {
-                        enabled: usePreventOverflow
-                      }
-                    }}
-                  >
-                    {({ ref, style, placement, arrowProps }) => (
-                      <StyledTooltip
-                        ref={ref}
-                        style={{
-                          ...style,
-                          ...this.props.style
+              {state => {
+                return isOpen
+                  ? this._getPopper(
+                      <Popper
+                        positionFixed={positionFixed}
+                        placement={placement}
+                        modifiers={{
+                          preventOverflow: {
+                            enabled: usePreventOverflow
+                          },
+                          hide: {
+                            enabled: usePreventOverflow
+                          }
                         }}
-                        transitionState={state}
-                        transitionDuration={transitionDuration}
-                        data-placement={placement}
                       >
-                        {title}
-                        <StyledTooltipArrow
-                          ref={arrowProps.ref}
-                          data-placement={placement}
-                          style={{
-                            ...arrowProps.style,
-                            ...arrowStyle
-                          }}
-                        />
-                      </StyledTooltip>
-                    )}
-                  </Popper>,
-                  appendToBody
-                )
-              : null;
-          }}
-        </Transition>
-      </Manager>
+                        {({ ref, style, placement, arrowProps }) => (
+                          <StyledTooltip
+                            ref={ref}
+                            style={{
+                              ...style,
+                              ...this.props.style
+                            }}
+                            transitionState={state}
+                            transitionDuration={transitionDuration}
+                            data-placement={placement}
+                          >
+                            {title}
+                            <StyledTooltipArrow
+                              ref={arrowProps.ref}
+                              data-placement={placement}
+                              style={{
+                                ...arrowProps.style,
+                                ...arrowStyle
+                              }}
+                            />
+                          </StyledTooltip>
+                        )}
+                      </Popper>,
+                      appendToBody
+                    )
+                  : null;
+              }}
+            </Transition>
+          </Manager>
+        )}
+      </ThemeContext.Consumer>
     );
   }
 }
@@ -164,9 +166,10 @@ Tooltip.propTypes = {
 Tooltip.defaultProps = {
   title: '',
   placement: undefined,
-  transitionDuration: 200
+  transitionDuration: 200,
+  enterDelay: undefined
 };
 
 Tooltip.displayName = 'Tooltip';
 
-export default withTheme(Tooltip);
+export default Tooltip;

--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -155,7 +155,7 @@ Tooltip.propTypes = {
   positionFixed: PropTypes.bool,
   /** Duration of animation in milliseconds. */
   transitionDuration: PropTypes.number,
-  /** Delay (in milliseconds) before the Tooltip will show. Prop overrides the value specified in the theme. */
+  /** Delay (in milliseconds) before the Tooltip will show. Prop overrides the value specified in the theme (0ms). */
   enterDelay: PropTypes.number,
   /** Apply styles to the Tooltip element. */
   style: PropTypes.object,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a `tooltipEnterDelay` property to the CalciteTheme and uses it as the default value to be passed to the react-transition-group Transition component, but can be overridden by the `enterDelay` prop.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#300 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To allow the enterDelay for Tooltips to be controlled on an app-wide basis while maintaining the ability to individually adjust each instance.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Via Tooltip documentation page
- Not passing an `enterDelay` prop or passing `enterDelay={undefined}` => uses the theme value
- Passing `enterDelay={null}` => tooltip does not open
- Passing any other value as a prop => overrides the value specified in the theme

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
