### PR TITLE
Update popper elements on content resize

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20128,6 +20128,11 @@
         "@babel/runtime": "^7.0.0"
       }
     },
+    "react-resize-aware": {
+      "version": "3.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/react-resize-aware/-/react-resize-aware-3.0.0-beta.5.tgz",
+      "integrity": "sha512-GpCOcOjyNX6IG9iTwHLtFBhuIbPBJjAw91CFj8o4nPy0kSHh0tPgGzW86wV9kd7A6Cpvu3H9Uga340MpNJyCcg=="
+    },
     "react-router": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-4.3.1.tgz",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "react-is": "^16.8.6",
     "react-modal": "^3.5.1",
     "react-popper": "^1.3.3",
+    "react-resize-aware": "^3.0.0-beta.5",
     "react-toastify": "^4.3.0",
     "react-transition-group": "^2.4.0",
     "react-virtualized": "^9.20.1",

--- a/src/MultiSelect/MultiSelect-styled.js
+++ b/src/MultiSelect/MultiSelect-styled.js
@@ -60,6 +60,10 @@ const StyledMultiSelectMenu = styled(Menu)`
     css`
       width: 100%;
     `};
+
+  iframe {
+    border: none;
+  }
 `;
 StyledMultiSelectMenu.defaultProps = { theme };
 

--- a/src/MultiSelect/MultiSelect.js
+++ b/src/MultiSelect/MultiSelect.js
@@ -19,9 +19,10 @@ import { Manager, Reference, Popper } from 'react-popper';
 
 import {
   StyledMultiSelectWrapper,
-  StyledMultiSelectButton,
-  StyledMultiSelectMenu
+  StyledMultiSelectButton
 } from './MultiSelect-styled';
+
+import MultiSelectMenu from './MultiSelectMenu';
 
 import { FormControlContext } from '../Form/FormControl';
 import { PopoverContext } from '../Popover/Popover';
@@ -308,20 +309,26 @@ const MultiSelect = ({
                         }
                       }}
                     >
-                      {({ ref: popperRef, style, placement }) => (
-                        <StyledMultiSelectMenu
-                          ref={popperRef}
+                      {({
+                        ref: popperRef,
+                        style,
+                        placement,
+                        scheduleUpdate
+                      }) => (
+                        <MultiSelectMenu
+                          innerRef={popperRef}
                           style={{ ...style, ...menuStyle }}
                           fullWidth={fullWidth}
                           data-placement={placement}
                           isOpen={isOpen}
+                          scheduleUpdate={scheduleUpdate}
                         >
                           {getMenuItems(children, {
                             getItemProps,
                             highlightedIndex,
                             selectedValues
                           })}
-                        </StyledMultiSelectMenu>
+                        </MultiSelectMenu>
                       )}
                     </Popper>,
                     isOpen,

--- a/src/MultiSelect/MultiSelectMenu.js
+++ b/src/MultiSelect/MultiSelectMenu.js
@@ -1,0 +1,43 @@
+// Framework and third-party non-ui
+import React from 'react';
+import PropTypes from 'prop-types';
+
+// Redux operations and local helpers/utils/modules
+import useResizeAware from 'react-resize-aware';
+
+// Component specific modules (Component-styled, etc.)
+import { StyledMultiSelectMenu } from './MultiSelect-styled';
+
+// App components
+
+// Third-party components (buttons, icons, etc.)
+
+// JSON
+
+// CSS
+
+const MultiSelectMenu = ({ innerRef, scheduleUpdate, children, ...other }) => {
+  const resizeReporter = target => {
+    target && scheduleUpdate && scheduleUpdate();
+  };
+
+  const [resizeListener] = useResizeAware(resizeReporter);
+
+  return (
+    <StyledMultiSelectMenu ref={innerRef} {...other}>
+      {resizeListener}
+      {children}
+    </StyledMultiSelectMenu>
+  );
+};
+
+MultiSelectMenu.propTypes = {
+  /** Ref of the Popper wrapping this component */
+  innerRef: PropTypes.func,
+  /** Popper method to call when the component resizes */
+  scheduleUpdate: PropTypes.func
+};
+
+MultiSelectMenu.defaultProps = {};
+
+export default MultiSelectMenu;

--- a/src/Popover/Popover-styled.js
+++ b/src/Popover/Popover-styled.js
@@ -53,6 +53,10 @@ const StyledPopover = styled.div`
       opacity: 1;
       pointer-events: auto;
     `};
+
+  iframe {
+    border: none;
+  }
 `;
 StyledPopover.defaultProps = { theme };
 

--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -17,7 +17,9 @@ import outy from 'outy';
 import { Manager, Reference, Popper } from 'react-popper';
 import uniqid from 'uniqid';
 
-import { StyledTargetWrapper, StyledPopover } from './Popover-styled';
+import { StyledTargetWrapper } from './Popover-styled';
+
+import PopoverPopper from './PopoverPopper';
 
 const PopoverContext = createContext({
   popoverContext: {
@@ -122,10 +124,10 @@ class Popover extends Component {
                         }
                       }}
                     >
-                      {({ ref, style, placement }) => {
+                      {({ ref, style, placement, scheduleUpdate }) => {
                         return (
-                          <StyledPopover
-                            ref={ref}
+                          <PopoverPopper
+                            innerRef={ref}
                             id={`${this._generatedId}Popover`}
                             style={{
                               ...style,
@@ -134,9 +136,10 @@ class Popover extends Component {
                             transitionState={state}
                             transitionDuration={this.props.transitionDuration}
                             data-placement={placement}
+                            scheduleUpdate={scheduleUpdate}
                           >
                             {this.props.children}
-                          </StyledPopover>
+                          </PopoverPopper>
                         );
                       }}
                     </Popper>,

--- a/src/Popover/PopoverPopper.js
+++ b/src/Popover/PopoverPopper.js
@@ -1,0 +1,43 @@
+// Framework and third-party non-ui
+import React from 'react';
+import PropTypes from 'prop-types';
+
+// Redux operations and local helpers/utils/modules
+import useResizeAware from 'react-resize-aware';
+
+// Component specific modules (Component-styled, etc.)
+import { StyledPopover } from './Popover-styled';
+
+// App components
+
+// Third-party components (buttons, icons, etc.)
+
+// JSON
+
+// CSS
+
+const PopoverPopper = ({ innerRef, scheduleUpdate, children, ...other }) => {
+  const resizeReporter = target => {
+    target && scheduleUpdate && scheduleUpdate();
+  };
+
+  const [resizeListener] = useResizeAware(resizeReporter);
+
+  return (
+    <StyledPopover ref={innerRef} {...other}>
+      {resizeListener}
+      {children}
+    </StyledPopover>
+  );
+};
+
+PopoverPopper.propTypes = {
+  /** Ref of the Popper wrapping this component */
+  innerRef: PropTypes.func,
+  /** Popper method to call when the component resizes */
+  scheduleUpdate: PropTypes.func
+};
+
+PopoverPopper.defaultProps = {};
+
+export default PopoverPopper;

--- a/src/Popover/doc/Popover.mdx
+++ b/src/Popover/doc/Popover.mdx
@@ -278,6 +278,56 @@ import Popover from 'calcite-react/Popover'
 
 </Playground>
 
+## With Image
+
+<Playground style={{ height: '375px' }}>
+  {() => {
+      class PopoverStory extends React.Component {
+        constructor(props) {
+          super(props);
+          this.state = {
+            open: false
+          };
+
+          this.togglePopover = this.togglePopover.bind(this);
+          this.closePopover = this.closePopover.bind(this);
+        }
+
+        togglePopover() {
+          this.setState({
+            open: !this.state.open
+          });
+        };
+
+        closePopover() {
+          this.setState({
+            open: false
+          });
+        };
+
+        render() {
+          return (
+            <Popover
+              targetEl={
+                <Button onClick={this.togglePopover}>Click Here</Button>
+              }
+              open={this.state.open}
+              onRequestClose={this.closePopover}
+            >
+              <Panel white noBorder>
+                <p>Here comes a big photo!</p>
+                <img src="https://source.unsplash.com/collection/1270951/800x600" alt="Random photo from unsplash.com" />
+              </Panel>
+            </Popover>
+          );
+        }
+      }
+
+      return <PopoverStory />;
+    }}
+
+</Playground>
+
 ## Props
 
 <PropsTable of={Popover} />

--- a/src/Search/Search.js
+++ b/src/Search/Search.js
@@ -29,7 +29,7 @@ import {
   PopperStyle
 } from './Search-styled';
 
-import { StyledSelectMenu } from '../Select/Select-styled';
+import SearchMenu from './SearchMenu';
 import { MenuItem } from '../Menu';
 import Tooltip from '../Tooltip';
 import { ListContext } from '../List/List';
@@ -398,9 +398,9 @@ class Search extends Component {
                               }
                             }}
                           >
-                            {({ ref, style, placement, arrowProps }) => (
-                              <StyledSelectMenu
-                                ref={ref}
+                            {({ ref, style, placement, scheduleUpdate }) => (
+                              <SearchMenu
+                                innerRef={ref}
                                 fullWidth={fullWidth}
                                 style={{
                                   ...style,
@@ -408,6 +408,7 @@ class Search extends Component {
                                 }}
                                 isOpen={isOpen}
                                 data-placement={placement}
+                                scheduleUpdate={scheduleUpdate}
                               >
                                 {this.getMenuItems(itemsToShow, virtualized, {
                                   highlightedIndex,
@@ -417,7 +418,7 @@ class Search extends Component {
                                   getItemProps,
                                   selectedItem
                                 })}
-                              </StyledSelectMenu>
+                              </SearchMenu>
                             )}
                           </Popper>,
                           appendToBody

--- a/src/Search/SearchMenu.js
+++ b/src/Search/SearchMenu.js
@@ -1,0 +1,43 @@
+// Framework and third-party non-ui
+import React from 'react';
+import PropTypes from 'prop-types';
+
+// Redux operations and local helpers/utils/modules
+import useResizeAware from 'react-resize-aware';
+
+// Component specific modules (Component-styled, etc.)
+import { StyledSelectMenu } from '../Select/Select-styled';
+
+// App components
+
+// Third-party components (buttons, icons, etc.)
+
+// JSON
+
+// CSS
+
+const SearchMenu = ({ innerRef, scheduleUpdate, children, ...other }) => {
+  const resizeReporter = target => {
+    target && scheduleUpdate && scheduleUpdate();
+  };
+
+  const [resizeListener] = useResizeAware(resizeReporter);
+
+  return (
+    <StyledSelectMenu ref={innerRef} {...other}>
+      {resizeListener}
+      {children}
+    </StyledSelectMenu>
+  );
+};
+
+SearchMenu.propTypes = {
+  /** Ref of the Popper wrapping this component */
+  innerRef: PropTypes.func,
+  /** Popper method to call when the component resizes */
+  scheduleUpdate: PropTypes.func
+};
+
+SearchMenu.defaultProps = {};
+
+export default SearchMenu;

--- a/src/Select/Select-styled.js
+++ b/src/Select/Select-styled.js
@@ -72,6 +72,11 @@ const StyledSelectMenu = styled(Menu)`
     css`
       min-width: 100%;
     `};
+
+  /* Handles iframe styling from react-resize-aware */
+  iframe {
+    border: none;
+  }
 `;
 StyledSelectMenu.defaultProps = { theme };
 

--- a/src/Select/Select.js
+++ b/src/Select/Select.js
@@ -22,10 +22,10 @@ import {
   StyledSelectWrapper,
   StyledSelectButton,
   StyledSelectInput,
-  StyledSelectMenu,
   PopperManagerStyles
 } from './Select-styled';
 
+import SelectMenu from './SelectMenu';
 import { FormControlContext } from '../Form/FormControl';
 import { PopoverContext } from '../Popover/Popover';
 
@@ -435,30 +435,34 @@ class Select extends Component {
                             }
                           }}
                         >
-                          {({ ref, style: popperStyle, placement }) => {
-                            return (
-                              <StyledSelectMenu
-                                ref={ref}
-                                style={{
-                                  ...popperStyle,
-                                  ...this.getFullWidthStyle(),
-                                  ...menuStyle
-                                }}
-                                isOpen={isOpen}
-                                data-placement={placement}
-                                fullWidth={fullWidth}
-                              >
-                                {this.getMenuItems(filteredList, virtualized, {
-                                  highlightedIndex,
-                                  menuHeight,
-                                  virtualizedRowHeight,
-                                  virtualizedMenuWidth,
-                                  getItemProps,
-                                  selectedItem
-                                })}
-                              </StyledSelectMenu>
-                            );
-                          }}
+                          {({
+                            ref,
+                            style: popperStyle,
+                            placement,
+                            scheduleUpdate
+                          }) => (
+                            <SelectMenu
+                              innerRef={ref}
+                              style={{
+                                ...popperStyle,
+                                ...this.getFullWidthStyle(),
+                                ...menuStyle
+                              }}
+                              isOpen={isOpen}
+                              data-placement={placement}
+                              fullWidth={fullWidth}
+                              scheduleUpdate={scheduleUpdate}
+                            >
+                              {this.getMenuItems(filteredList, virtualized, {
+                                highlightedIndex,
+                                menuHeight,
+                                virtualizedRowHeight,
+                                virtualizedMenuWidth,
+                                getItemProps,
+                                selectedItem
+                              })}
+                            </SelectMenu>
+                          )}
                         </Popper>
                       ),
                       isOpen,

--- a/src/Select/SelectMenu.js
+++ b/src/Select/SelectMenu.js
@@ -1,0 +1,43 @@
+// Framework and third-party non-ui
+import React from 'react';
+import PropTypes from 'prop-types';
+
+// Redux operations and local helpers/utils/modules
+import useResizeAware from 'react-resize-aware';
+
+// Component specific modules (Component-styled, etc.)
+import { StyledSelectMenu } from './Select-styled';
+
+// App components
+
+// Third-party components (buttons, icons, etc.)
+
+// JSON
+
+// CSS
+
+const SelectMenu = ({ children, innerRef, scheduleUpdate, ...other }) => {
+  const resizeReporter = target => {
+    target && scheduleUpdate && scheduleUpdate();
+  };
+
+  const [resizeListener] = useResizeAware(resizeReporter);
+
+  return (
+    <StyledSelectMenu ref={innerRef} {...other}>
+      {resizeListener}
+      {children}
+    </StyledSelectMenu>
+  );
+};
+
+SelectMenu.propTypes = {
+  /** Ref of the Popper wrapping this component */
+  innerRef: PropTypes.func,
+  /** Popper method to call when the component resizes */
+  scheduleUpdate: PropTypes.func
+};
+
+SelectMenu.defaultProps = {};
+
+export default SelectMenu;

--- a/src/Tooltip/Tooltip-styled.js
+++ b/src/Tooltip/Tooltip-styled.js
@@ -72,6 +72,11 @@ const StyledTooltip = styled.div`
     css`
       opacity: 1;
     `};
+
+  /* Handles iframe styling from react-resize-aware */
+  iframe {
+    border: none;
+  }
 `;
 StyledTooltip.defaultProps = { theme };
 

--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -15,11 +15,9 @@ import Transition from 'react-transition-group/Transition';
 import PropTypes from 'prop-types';
 import { Manager, Reference, Popper } from 'react-popper';
 
-import {
-  StyledTargetWrapper,
-  StyledTooltip,
-  StyledTooltipArrow
-} from './Tooltip-styled';
+import { StyledTargetWrapper, StyledTooltipArrow } from './Tooltip-styled';
+
+import TooltipPopper from './TooltipPopper';
 
 class Tooltip extends Component {
   constructor(props) {
@@ -96,9 +94,15 @@ class Tooltip extends Component {
                       }
                     }}
                   >
-                    {({ ref, style, placement, arrowProps }) => (
-                      <StyledTooltip
-                        ref={ref}
+                    {({
+                      ref,
+                      style,
+                      placement,
+                      arrowProps,
+                      scheduleUpdate
+                    }) => (
+                      <TooltipPopper
+                        innerRef={ref}
                         style={{
                           ...style,
                           ...this.props.style
@@ -106,6 +110,7 @@ class Tooltip extends Component {
                         transitionState={state}
                         transitionDuration={transitionDuration}
                         data-placement={placement}
+                        scheduleUpdate={scheduleUpdate}
                       >
                         {title}
                         <StyledTooltipArrow
@@ -116,7 +121,7 @@ class Tooltip extends Component {
                             ...arrowStyle
                           }}
                         />
-                      </StyledTooltip>
+                      </TooltipPopper>
                     )}
                   </Popper>,
                   appendToBody

--- a/src/Tooltip/TooltipPopper.js
+++ b/src/Tooltip/TooltipPopper.js
@@ -1,0 +1,43 @@
+// Framework and third-party non-ui
+import React from 'react';
+import PropTypes from 'prop-types';
+
+// Redux operations and local helpers/utils/modules
+import useResizeAware from 'react-resize-aware';
+
+// Component specific modules (Component-styled, etc.)
+import { StyledTooltip } from './Tooltip-styled';
+
+// App components
+
+// Third-party components (buttons, icons, etc.)
+
+// JSON
+
+// CSS
+
+const TooltipPopper = ({ innerRef, scheduleUpdate, children, ...other }) => {
+  const resizeReporter = target => {
+    target && scheduleUpdate && scheduleUpdate();
+  };
+
+  const [resizeListener] = useResizeAware(resizeReporter);
+
+  return (
+    <StyledTooltip ref={innerRef} {...other}>
+      {resizeListener}
+      {children}
+    </StyledTooltip>
+  );
+};
+
+TooltipPopper.propTypes = {
+  /** Ref of the Popper wrapping this component */
+  innerRef: PropTypes.func,
+  /** Popper method to call when the component resizes */
+  scheduleUpdate: PropTypes.func
+};
+
+TooltipPopper.defaultProps = {};
+
+export default TooltipPopper;


### PR DESCRIPTION
## Description
Implement `scheduleUpdate` for popper elements so that we can reposition them when the content resizes.

## Motivation and Context
Fixes an issue where menus wouldn't reposition even if the number of items in the list changed or if new elements rendered after initial open.

## How Has This Been Tested?
Tested in docs and added another doc example for `Popover` with an image that would load after initial open.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
