### PR TITLE
Add token prop to ArcgisItemCard

### DIFF
--- a/src/ArcgisItemCard/ArcgisItemCard.js
+++ b/src/ArcgisItemCard/ArcgisItemCard.js
@@ -29,14 +29,16 @@ const ArcgisItemCard = ({
   dateFormatter,
   maxDescriptionLength,
   portal,
+  token,
   ...other
 }) => {
   let imageEl;
   let hostname = portal ? portal.portalHostname : 'arcgis.com';
   if (showThumbnail) {
+    const tokenUrlParam = token ? `?token=${token}` : '';
     const imageSource = `https://${hostname}/sharing/rest/content/items/${
       item.id
-    }/info/${item.thumbnail}`;
+    }/info/${item.thumbnail}${tokenUrlParam}`;
     imageEl = <StyledItemCardImageWrap imageSource={imageSource} />;
   }
 
@@ -108,7 +110,9 @@ ArcgisItemCard.propTypes = {
   /** Number of characters to use before truncating the description text. */
   maxDescriptionLength: PropTypes.number,
   /** AGOL portal object - if not specified will default to ArcGIS Online */
-  portal: PropTypes.object
+  portal: PropTypes.object,
+  /** AGOL login token. */
+  token: PropTypes.string
 };
 
 ArcgisItemCard.defaultProps = {

--- a/src/ArcgisItemCard/doc/ArcgisItemCard.mdx
+++ b/src/ArcgisItemCard/doc/ArcgisItemCard.mdx
@@ -22,11 +22,7 @@ import ArcgisItemCard from 'calcite-react/ArcgisItemCard'
 ## Basic Usage
 
 <Playground>
-  <div>
-    <div>
-      <ArcgisItemCard item={item} />
-    </div>
-  </div>
+  <ArcgisItemCard item={item} />
 </Playground>
 
 ## Props

--- a/src/ArcgisShare/ArcgisShare-styled.js
+++ b/src/ArcgisShare/ArcgisShare-styled.js
@@ -41,15 +41,6 @@ const StyledGroupContainer = styled.div`
 `;
 StyledGroupContainer.defaultProps = { theme };
 
-const PrimaryCheckboxLabelStyles = {
-  fontSize: '1rem',
-  color: theme.palette.black
-};
-
-const GroupCheckboxLabelStyles = {
-  fontSize: '0.85rem'
-};
-
 const StyledGroupFieldset = styled(Fieldset)`
   margin-left: 1.4rem;
   display: flex;
@@ -60,6 +51,7 @@ const StyledGroupFieldset = styled(Fieldset)`
     margin-right: 1.4rem;
   }
 `;
+StyledGroupFieldset.defaultProps = { theme };
 
 const StyledStarIcon = styled(StarIcon)`
   fill: ${props => props.theme.palette.lighterGray};
@@ -91,6 +83,15 @@ const StyledNoGroups = styled.span`
   ${fontSize(-2)};
 `;
 StyledNoGroups.defaultProps = { theme };
+
+const PrimaryCheckboxLabelStyles = {
+  fontSize: '1rem',
+  color: theme.palette.black
+};
+
+const GroupCheckboxLabelStyles = {
+  fontSize: '0.85rem'
+};
 
 export {
   StyledArcgisShare,


### PR DESCRIPTION
## Description
Adds support for private items so that we can still show thumbnails.

## Related Issue
#312 

## Motivation and Context
Arjan van Zutphen from Esri Netherlands pointed out that our item card wasn't displaying thumbnails for private items.

## How Has This Been Tested?
Still needs testing, what's a good way to try this out?

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
