### PR TITLE
Fix autoSelect behavior in a formik field

### DIFF
--- a/src/Select/Select.js
+++ b/src/Select/Select.js
@@ -180,9 +180,11 @@ class Select extends Component {
   };
 
   handleBlur = e => {
-    const { onBlur, field } = this.props;
+    const { onBlur, field, autoSelect } = this.props;
 
-    if (field) {
+    // Ignore field blur if autoSelect
+    // Blur behavior is handled by downshift stateReducer
+    if (!autoSelect && field) {
       field.onBlur(e);
     }
 
@@ -377,8 +379,8 @@ class Select extends Component {
         const selectedItem = items[state.highlightedIndex];
 
         selectedItemIndex =
-          changes.selectedItem &&
-          this.getItemIndexFromChildren(changes.selectedItem.props.value);
+          selectedItem &&
+          this.getItemIndexFromChildren(selectedItem.props.value);
 
         // Set the new selectedItem
         return {

--- a/src/Select/doc/Select.mdx
+++ b/src/Select/doc/Select.mdx
@@ -369,7 +369,7 @@ import Select from 'calcite-react/Select';
           const errors = {};
           if (!values.state) {
             errors.state = 'Required 🤨';
-          } else if (values.state !== 'CO') {
+          } else if (values.state !== 'Colorado') {
             errors.state = 'You have to live in Colorado to use this form 😉';
           }
 
@@ -395,9 +395,13 @@ import Select from 'calcite-react/Select';
                       State:
                     </FormControlLabel>
                     <Field component={Select} name="state">
-                      <MenuItem value="CA">California</MenuItem>
-                      <MenuItem value="CO">Colorado</MenuItem>
-                      <MenuItem value="MD">Maryland</MenuItem>
+                      {statesJson.states.map(state => {
+                        return (
+                          <MenuItem key={state} value={state}>
+                            {state}
+                          </MenuItem>
+                        );
+                      })}
                     </Field>
                     <FormHelperText>
                       {(touched.state && errors.state) || null}


### PR DESCRIPTION
## Description
Fixes a bug where `Select` with `autoSelect` inside a formik `Field` was selecting the incorrect value on blur. Implementation basically ignores the formik field's `onBlur` callback when `autoSelect` is set. We rely on the Downshift `stateReducer` to set the selected item on blur.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
