### PR TITLE
Switch label size and fullWidth prop

### DIFF
--- a/src/Form/Form-styled.js
+++ b/src/Form/Form-styled.js
@@ -130,6 +130,7 @@ const StyledFormHelperText = styled.span`
 StyledFormHelperText.defaultProps = { theme };
 
 const StyledLegend = styled.legend`
+  ${fontSize(0)}
   position: relative;
   display: block;
   margin-bottom: 0.25rem;

--- a/src/Form/Form-styled.js
+++ b/src/Form/Form-styled.js
@@ -82,6 +82,7 @@ const StyledFormControl = styled.div`
 StyledFormControl.defaultProps = { theme };
 
 const StyledFormControlLabel = styled.label`
+  ${fontSize(0)}
   display: flex;
   flex-direction: column;
 

--- a/src/Switch/Switch-styled.js
+++ b/src/Switch/Switch-styled.js
@@ -20,6 +20,7 @@ import { baseRadioCheckbox } from '../utils/commonElements';
 import { CalciteTheme as theme, EsriColors } from '../CalciteThemeProvider';
 
 // Calcite components
+import { StyledFormControlLabel } from '../Form/Form-styled';
 
 // Icons
 
@@ -72,12 +73,18 @@ const switchProps = {
 };
 
 const StyledSwitch = styled.label`
-  display: block;
+  display: flex;
   position: relative;
   cursor: pointer;
   user-select: none;
   tap-highlight-color: transparent;
   margin: 0 0 ${props => props.theme.baseline} 0;
+
+  ${props =>
+    props.fullWidth &&
+    css`
+      width: 100%;
+    `};
 `;
 StyledSwitch.defaultProps = { theme };
 
@@ -102,6 +109,7 @@ const StyledSwitchTrack = styled.span`
   border: 1px solid ${switchProps.switchBorderColor};
   transition: all 250ms cubic-bezier(0.4, 0, 0.2, 1);
   margin-right: 1rem;
+  flex-shrink: 0;
 
   html[dir='rtl'] & {
     margin-right: 0;
@@ -272,20 +280,25 @@ const StyledSwitchTrack = styled.span`
 `;
 StyledSwitchTrack.defaultProps = { theme };
 
-const StyledSwitchLabel = styled.span`
-  ${fontSize(-1)};
-  width: calc((100% - 3em) - 0.5em);
-  padding: 0 0.1em;
+const StyledSwitchLabel = styled(StyledFormControlLabel)`
   vertical-align: top;
+  text-align: end;
 
   &:first-child {
     margin-right: 1rem;
+    text-align: start;
 
     html[dir='rtl'] & {
       margin-right: 0;
       margin-left: 1rem;
     }
   }
+
+  ${props =>
+    props.fullWidth &&
+    css`
+      flex: 1 0 auto;
+    `};
 `;
 StyledSwitchLabel.defaultProps = { theme };
 

--- a/src/Switch/Switch-styled.js
+++ b/src/Switch/Switch-styled.js
@@ -282,11 +282,11 @@ StyledSwitchTrack.defaultProps = { theme };
 
 const StyledSwitchLabel = styled(StyledFormControlLabel)`
   vertical-align: top;
-  text-align: end;
+  text-align: right;
 
   &:first-child {
     margin-right: 1rem;
-    text-align: start;
+    text-align: initial;
 
     html[dir='rtl'] & {
       margin-right: 0;

--- a/src/Switch/Switch.js
+++ b/src/Switch/Switch.js
@@ -22,6 +22,7 @@ import {
 const Switch = ({
   children,
   labelPosition,
+  fullWidth,
   destructive,
   checked,
   field,
@@ -45,7 +46,9 @@ const Switch = ({
 
   const getSwitchLabel = children => {
     if (children) {
-      return <StyledSwitchLabel>{children}</StyledSwitchLabel>;
+      return (
+        <StyledSwitchLabel fullWidth={fullWidth}>{children}</StyledSwitchLabel>
+      );
     }
   };
 
@@ -84,7 +87,7 @@ const Switch = ({
   };
 
   return (
-    <StyledSwitch>
+    <StyledSwitch fullWidth={fullWidth}>
       {labelPosition === 'before' ? getSwitchLabel(children) : null}
       <StyledSwitchInput
         onChange={handleChange}
@@ -113,7 +116,9 @@ Switch.propTypes = {
   /** Should use a red highlight color. */
   destructive: PropTypes.bool,
   /** Position of the label text in relation to the input. */
-  labelPosition: PropTypes.oneOf(['before', 'after'])
+  labelPosition: PropTypes.oneOf(['before', 'after']),
+  /** Switch and label will take up the full width of the container */
+  fullWidth: PropTypes.bool
 };
 
 Switch.defaultProps = {

--- a/src/Switch/doc/Switch.mdx
+++ b/src/Switch/doc/Switch.mdx
@@ -30,20 +30,25 @@ import Switch from 'calcite-react/Switch'
 ## Alternate Styles
 
 <Playground>
-  <Form>
-    <GuideExample label="destructive">
-      <FormControl>
-        <Switch destructive>
-          Confirm account deletion. You cannot recover deleted accounts.
-        </Switch>
-      </FormControl>
-    </GuideExample>
-    <GuideExample label="labelPosition='before'">
-      <FormControl>
-        <Switch labelPosition="before">Enable Two-Factor Authentication</Switch>
-      </FormControl>
-    </GuideExample>
-  </Form>
+  <GuideExample label="destructive">
+    <Switch destructive>
+      Confirm account deletion. You cannot recover deleted accounts.
+    </Switch>
+  </GuideExample>
+  <GuideExample label="labelPosition='before'">
+    <Switch labelPosition="before">Enable Two-Factor Authentication</Switch>
+  </GuideExample>
+</Playground>
+
+## fullWidth
+
+<Playground>
+  <GuideExample>
+    <Switch fullWidth>Enable Two-Factor Authentication</Switch>
+  </GuideExample>
+  <GuideExample>
+    <Switch fullWidth labelPosition="before">Enable Two-Factor Authentication</Switch>
+  </GuideExample>
 </Playground>
 
 ## with Formik


### PR DESCRIPTION
## Description
- [x] Standardize font size of `FormControlLabel` and `Switch` label
- [x] Add `fullWidth` prop to `Switch`

## Motivation and Context
Switches in forms look off when the label sizes don't match. Horizontal forms with inputs right aligned should be supported by `Switch`

## Screenshots (if appropriate):
![Screen Shot 2019-12-05 at 1 18 51 PM](https://user-images.githubusercontent.com/5149922/70270496-cf92ea80-1761-11ea-8a78-71e9fc08bda9.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
