### PR TITLE
Fix poppers off screen

### DIFF
--- a/src/MultiSelect/MultiSelect.js
+++ b/src/MultiSelect/MultiSelect.js
@@ -49,6 +49,7 @@ const MultiSelect = ({
   virtualized,
   virtualizedRowHeight,
   virtualizedMenuWidth,
+  popperModifiers,
   ...other
 }) => {
   let name, touched, errors, isSubmitting, setFieldValue;
@@ -301,14 +302,7 @@ const MultiSelect = ({
                     <Popper
                       positionFixed={positionFixed}
                       placement={rtlPlacement(other.placement)}
-                      modifiers={{
-                        preventOverflow: {
-                          enabled: appendToBody || positionFixed ? false : true
-                        },
-                        hide: {
-                          enabled: appendToBody || positionFixed ? false : true
-                        }
-                      }}
+                      modifiers={popperModifiers}
                     >
                       {({
                         ref: popperRef,
@@ -391,7 +385,9 @@ MultiSelect.propTypes = {
   /** (virtualized only) Row height used to calculate how many rows to render in a virtualized Menu. */
   virtualizedRowHeight: PropTypes.oneOfType([PropTypes.number, PropTypes.func]),
   /** (virtualized only) Width of the menu; unloaded rows may be wider than the initial set. */
-  virtualizedMenuWidth: PropTypes.number
+  virtualizedMenuWidth: PropTypes.number,
+  /** Modifiers to be passed to the Popper element */
+  popperModifiers: PropTypes.object
 };
 
 MultiSelect.defaultProps = {

--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -92,9 +92,6 @@ class Popover extends Component {
   };
 
   render() {
-    const usePreventOverflow =
-      this.props.appendToBody || this.props.positionFixed ? false : true;
-
     return (
       <PopoverContext.Provider value={{ popoverContext: this.popoverContext }}>
         <Manager>
@@ -116,14 +113,7 @@ class Popover extends Component {
                     <Popper
                       positionFixed={this.props.positionFixed}
                       placement={rtlPlacement(this.props.placement)}
-                      modifiers={{
-                        preventOverflow: {
-                          enabled: usePreventOverflow
-                        },
-                        hide: {
-                          enabled: usePreventOverflow
-                        }
-                      }}
+                      modifiers={this.props.popperModifiers}
                     >
                       {({ ref, style, placement, scheduleUpdate }) => {
                         return (
@@ -190,7 +180,9 @@ Popover.propTypes = {
   /** Styles passed onto the Popover container div. */
   popoverContainerStyles: PropTypes.object,
   /** Uses `position: fixed` on the tooltip allowing it to show up outside of containers that have `overflow: hidden`. */
-  positionFixed: PropTypes.bool
+  positionFixed: PropTypes.bool,
+  /** Modifiers to be passed to the Popper element */
+  popperModifiers: PropTypes.object
 };
 
 Popover.defaultProps = {

--- a/src/Search/Search.js
+++ b/src/Search/Search.js
@@ -390,14 +390,7 @@ class Search extends Component {
                               ...PopperStyle
                             }}
                             placement={rtlPlacement(this.props.placement)}
-                            modifiers={{
-                              preventOverflow: {
-                                enabled: usePreventOverflow
-                              },
-                              hide: {
-                                enabled: usePreventOverflow
-                              }
-                            }}
+                            modifiers={this.props.popperModifiers}
                           >
                             {({ ref, style, placement, scheduleUpdate }) => (
                               <SearchMenu
@@ -497,7 +490,9 @@ Search.propTypes = {
   /** SVG icon to clear the value of the Search input */
   clearIcon: PropTypes.node,
   /** Use a remote API for the data load.  This will allow the application to see the exact return from the API with no filtering applied */
-  remote: PropTypes.bool
+  remote: PropTypes.bool,
+  /** Modifiers to be passed to the Popper element */
+  popperModifiers: PropTypes.object
 };
 
 Search.defaultProps = {

--- a/src/Select/Select.js
+++ b/src/Select/Select.js
@@ -431,10 +431,10 @@ class Select extends Component {
       virtualizedRowHeight,
       virtualizedMenuWidth,
       autoSelect,
+      popperModifiers,
       ...other
     } = this.props;
 
-    const popperModifiersEnabled = appendToBody || positionFixed ? false : true;
     const menuHeight =
       (menuStyle && parseInt(menuStyle.height, 10)) ||
       (menuStyle && parseInt(menuStyle.maxHeight, 10)) ||
@@ -523,14 +523,7 @@ class Select extends Component {
                         <Popper
                           positionFixed={positionFixed}
                           placement={rtlPlacement(other.placement)}
-                          modifiers={{
-                            preventOverflow: {
-                              enabled: popperModifiersEnabled
-                            },
-                            hide: {
-                              enabled: popperModifiersEnabled
-                            }
-                          }}
+                          modifiers={popperModifiers}
                         >
                           {({
                             ref,
@@ -625,7 +618,9 @@ Select.propTypes = {
   /** (virtualized only) Row height used to calculate how many rows to render in a virtualized menu. */
   virtualizedRowHeight: PropTypes.oneOfType([PropTypes.number, PropTypes.func]),
   /** (virtualized only) Width of the menu; unloaded rows may be wider than the initial set. */
-  virtualizedMenuWidth: PropTypes.number
+  virtualizedMenuWidth: PropTypes.number,
+  /** Modifiers to be passed to the Popper element */
+  popperModifiers: PropTypes.object
 };
 
 Select.defaultProps = {

--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -61,12 +61,12 @@ class Tooltip extends Component {
       placement,
       transitionDuration,
       title,
-      arrowStyle
+      arrowStyle,
+      popperModifiers
     } = this.props;
 
     const isOpen =
       this.props.open !== undefined ? this.props.open : this.state.open;
-    const usePreventOverflow = appendToBody || positionFixed ? false : true;
 
     return (
       <ThemeContext.Consumer>
@@ -96,14 +96,7 @@ class Tooltip extends Component {
                       <Popper
                         positionFixed={positionFixed}
                         placement={rtlPlacement(placement)}
-                        modifiers={{
-                          preventOverflow: {
-                            enabled: usePreventOverflow
-                          },
-                          hide: {
-                            enabled: usePreventOverflow
-                          }
-                        }}
+                        modifiers={popperModifiers}
                       >
                         {({
                           ref,
@@ -181,7 +174,9 @@ Tooltip.propTypes = {
   /** Apply styles to the Tooltip arrow element. */
   arrowStyle: PropTypes.object,
   /** Apply styles to the Tooltip target wrapper element. */
-  targetWrapperStyle: PropTypes.object
+  targetWrapperStyle: PropTypes.object,
+  /** Modifiers to be passed to the Popper element */
+  popperModifiers: PropTypes.object
 };
 
 Tooltip.defaultProps = {


### PR DESCRIPTION
## Description
- Adds `popperModifiers` prop to manually pass [modifiers](https://popper.js.org/popper-documentation.html#modifiers) to the `Popper` element
  - Reverts some code I wrote when we added support for `positionFixed` and `appendToBody` that is no longer necessary.

## Motivation and Context
Popper components wouldn't position themselves correctly if the size of the content caused them to be positioned off screen. Components with `positionFixed` and `appendToBody` should now work properly.

## How Has This Been Tested?
Tested in docs

## Screenshots (if appropriate):
Old:
![Screen Shot 2019-12-17 at 10 11 07 AM](https://user-images.githubusercontent.com/5149922/71018369-93db1780-20b5-11ea-8ef3-9298bd40816b.png)

New:
![Screen Shot 2019-12-17 at 10 10 22 AM](https://user-images.githubusercontent.com/5149922/71018384-98073500-20b5-11ea-93bb-45958f834fc4.png)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
