### PR TITLE
Update Tooltip and Popover styles

### DIFF
--- a/src/CalciteThemeProvider/CalciteTheme.js
+++ b/src/CalciteThemeProvider/CalciteTheme.js
@@ -126,10 +126,9 @@ const CalciteTheme = {
   transition: '150ms linear',
   transitionDuration: '150ms',
   easingFunc: 'linear',
-  boxShadow: '0 0 16px 0 rgba(0,0,0,.05)',
+  boxShadow: 'rgba(0, 0, 0, 0.15) 0px 0px 16px 0px;',
   drawerWidth: '280px',
   borderRadius: 0,
-  tooltipEnterDelay: 0,
 
   // ┌─────────────┐
   // │ Type Colors │
@@ -149,6 +148,13 @@ const CalciteTheme = {
   // │ Grid Configuration │
   // └────────────────────┘
   prefix: '',
+
+  // ┌───────────────────┐
+  // │ Tooltip Variables │
+  // └───────────────────┘
+  tooltipBackgroundColor: EsriColors.Calcite_Gray_800,
+  tooltipBorderRadius: 0,
+  tooltipEnterDelay: 0,
 
   // ┌─────────┐
   // │ Toaster │

--- a/src/CalciteThemeProvider/EsriColors.js
+++ b/src/CalciteThemeProvider/EsriColors.js
@@ -116,6 +116,7 @@ const EsriColors = {
   Calcite_Gray_600: '#595959', // 65%, previously Esri_Gray150
   Calcite_Gray_650: '#4c4c4c', // 70%, previously Esri_Gray155. body text
   Calcite_Gray_700: '#323232', // 80%, previously Esri_Gray160
+  Calcite_Gray_800: '#2b2b2b',
 
   Calcite_Highlight_Blue_100: '#e2f1fb', // hovered, previously Esri_Blue1. NOTE--Esri_Blue2 was removed in Calcite Colors v8.00 due to it being so similar to Calcite_Highlight_Blue_100 and 150
   Calcite_Highlight_Blue_150: '#c5e5f9', // hovered & selected, previously Esri_Blue5

--- a/src/Popover/Popover-styled.js
+++ b/src/Popover/Popover-styled.js
@@ -18,6 +18,7 @@ import styled, { css } from 'styled-components';
 import { CalciteTheme as theme } from '../CalciteThemeProvider';
 
 // Calcite components
+import { StyledMenu } from '../Menu/Menu-styled';
 
 // Icons
 
@@ -53,6 +54,10 @@ const StyledPopover = styled.div`
       opacity: 1;
       pointer-events: auto;
     `};
+
+  ${StyledMenu} {
+    box-shadow: none;
+  }
 
   iframe {
     border: none;

--- a/src/Tooltip/Tooltip-styled.js
+++ b/src/Tooltip/Tooltip-styled.js
@@ -30,13 +30,13 @@ const StyledTargetWrapper = styled.div`
 StyledTargetWrapper.defaultProps = { theme };
 
 const StyledTooltip = styled.div`
-  padding: ${props => unitCalc(props.theme.baseline, 4, '/')}
+  padding: ${props => unitCalc(props.theme.baseline, 3, '/')}
     ${props => unitCalc(props.theme.baseline, 2, '/')};
   ${fontSize(-2)};
   color: ${props => props.theme.palette.white};
   text-align: center;
-  background: ${props => props.theme.palette.transparentBlack};
-  border-radius: ${props => props.theme.borderRadius || '3px'};
+  background: ${props => props.theme.tooltipBackgroundColor};
+  border-radius: ${props => props.theme.tooltipBorderRadius};
   max-width: 400px;
   opacity: 0;
   transition: opacity ${props => props.transitionDuration}ms
@@ -89,26 +89,26 @@ const StyledTooltipArrow = styled.div`
 
   &[data-placement^='top'] {
     border-width: 5px 5px 0 5px;
-    border-color: ${props => props.theme.palette.transparentBlack} transparent
+    border-color: ${props => props.theme.tooltipBackgroundColor} transparent
       transparent transparent;
     bottom: -5px;
   }
   &[data-placement^='bottom'] {
     border-width: 0 5px 5px 5px;
     border-color: transparent transparent
-      ${props => props.theme.palette.transparentBlack} transparent;
+      ${props => props.theme.tooltipBackgroundColor} transparent;
     top: -5px;
   }
   &[data-placement^='right'] {
     border-width: 5px 5px 5px 0;
-    border-color: transparent ${props => props.theme.palette.transparentBlack}
+    border-color: transparent ${props => props.theme.tooltipBackgroundColor}
       transparent transparent;
     left: -5px;
   }
   &[data-placement^='left'] {
     border-width: 5px 0 5px 5px;
     border-color: transparent transparent transparent
-      ${props => props.theme.palette.transparentBlack};
+      ${props => props.theme.tooltipBackgroundColor};
     right: -5px;
   }
 `;


### PR DESCRIPTION
## Description
- Add `Tooltip` specific theme values
- Fix duplicate `box-shadow` for `Menu` in a `Popover`
- Update some theme variables to match latest calcite components

## Motivation and Context
Work to align calcite react with latest styling from calcite components. Should also help with legibility of tooltips when they overlap with other text.

## Screenshots (if appropriate):
Old:
![Screen Shot 2019-12-19 at 4 28 38 PM](https://user-images.githubusercontent.com/5149922/71217895-a6537d80-227c-11ea-839f-2c14ffa248f7.png)

New:
![Screen Shot 2019-12-19 at 4 28 18 PM](https://user-images.githubusercontent.com/5149922/71217912-b9fee400-227c-11ea-882e-d017fcdd68d3.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
