### PR TITLE
Update Accordion styles

### DIFF
--- a/src/Accordion/Accordion-styled.js
+++ b/src/Accordion/Accordion-styled.js
@@ -13,7 +13,7 @@
 import styled, { css } from 'styled-components';
 
 // Utils, common elements
-import { transition } from '../utils/helpers';
+import { transition, fontSize, unitCalc } from '../utils/helpers';
 
 // Calcite theme and Esri colors
 import { CalciteTheme as theme } from '../CalciteThemeProvider';
@@ -26,60 +26,11 @@ import ChevronRightIcon from 'calcite-ui-icons-react/ChevronRightIcon';
 
 // Third party libraries
 
-const StyledAccordion = styled(StyledSideNav)`
-  border-radius: ${props => props.theme.borderRadius};
-`;
-StyledAccordion.defaultProps = { theme };
-
-const StyledAccordionSection = styled.div``;
-StyledAccordionSection.defaultProps = { theme };
-
-const StyledAccordionTitle = styled(StyledSideNavTitle)`
-  display: flex;
-  align-items: center;
-  cursor: pointer;
-
-  ${StyledAccordionSection}:first-child & {
-    border-top-left-radius: ${props => props.theme.borderRadius};
-    border-top-right-radius: ${props => props.theme.borderRadius};
-  }
-
-  ${StyledAccordionSection}:last-child & {
-    border-bottom-left-radius: ${props => props.theme.borderRadius};
-    border-bottom-right-radius: ${props => props.theme.borderRadius};
-  }
-
-  &:hover,
-  &:focus {
-    transition: all, ${transition()};
-    background-color: ${props => props.theme.palette.lightestGray};
-    outline: none;
-  }
-
-  ${props =>
-    props.disabled &&
-    css`
-      opacity: 0.5;
-      pointer-events: none;
-    `};
-`;
-StyledAccordionTitle.defaultProps = { theme };
-
-const StyledAccordionContent = styled.div`
-  display: none;
-
-  ${props =>
-    props.active &&
-    css`
-      display: block;
-    `};
-`;
-StyledAccordionContent.defaultProps = { theme };
-
 const StyledChevronIcon = styled(ChevronRightIcon)`
-  width: 20;
-  height: 20;
+  width: 16px;
+  height: 16px;
   transition: transform ${transition()};
+  margin-right: ${props => unitCalc(props.theme.baseline, 2, '/')};
 
   html[dir='rtl'] & {
     transform: rotate(180deg);
@@ -93,8 +44,107 @@ const StyledChevronIcon = styled(ChevronRightIcon)`
         transform: rotate(90deg);
       }
     `};
+
+  ${props =>
+    props.iconPosition === 'end' &&
+    css`
+      margin-right: initial;
+      transform: rotate(180deg);
+
+      html[dir='rtl'] & {
+        transform: rotate(0deg);
+      }
+
+      ${props =>
+        props.active === 'true' &&
+        css`
+          &,
+          html[dir='rtl'] & {
+            transform: rotate(90deg);
+          }
+        `};
+    `};
 `;
 StyledChevronIcon.defaultProps = { theme };
+
+const StyledAccordion = styled(StyledSideNav)`
+  border-radius: ${props => props.theme.borderRadius};
+`;
+StyledAccordion.defaultProps = { theme };
+
+const StyledAccordionSection = styled.div``;
+StyledAccordionSection.defaultProps = { theme };
+
+const StyledAccordionTitle = styled(StyledSideNavTitle)`
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  ${fontSize(-2)};
+  background-color: ${props => props.theme.palette.white};
+  color: ${props => props.theme.palette.darkerGray};
+  border-bottom: none;
+
+  &:hover,
+  &:focus {
+    background-color: ${props => props.theme.palette.white};
+    color: ${props => props.theme.palette.black};
+    outline: none;
+
+    ${StyledChevronIcon} {
+      color: ${props => props.theme.palette.blue};
+
+      ${props =>
+        props.active &&
+        css`
+          color: ${props => props.theme.palette.black};
+        `};
+    }
+  }
+
+  ${props =>
+    props.active &&
+    css`
+      border-bottom: 1px solid ${props => props.theme.palette.lightestGray};
+      color: ${props => props.theme.palette.black};
+      font-weight: 600;
+    `};
+
+  ${props =>
+    props.iconPosition === 'end' &&
+    css`
+      justify-content: space-between;
+    `};
+
+  ${StyledAccordionSection}:first-child & {
+    border-top-left-radius: ${props => props.theme.borderRadius};
+    border-top-right-radius: ${props => props.theme.borderRadius};
+  }
+
+  ${StyledAccordionSection}:last-child & {
+    border-bottom-left-radius: ${props => props.theme.borderRadius};
+    border-bottom-right-radius: ${props => props.theme.borderRadius};
+  }
+
+  ${props =>
+    props.disabled &&
+    css`
+      opacity: 0.5;
+      pointer-events: none;
+    `};
+`;
+StyledAccordionTitle.defaultProps = { theme };
+
+const StyledAccordionContent = styled.div`
+  display: none;
+  padding: ${props => unitCalc(props.theme.baseline, 2, '/')};
+
+  ${props =>
+    props.active &&
+    css`
+      display: block;
+    `};
+`;
+StyledAccordionContent.defaultProps = { theme };
 
 export {
   StyledAccordion,

--- a/src/Accordion/Accordion.js
+++ b/src/Accordion/Accordion.js
@@ -19,6 +19,7 @@ const Accordion = ({
   children,
   activeSectionIndexes,
   onAccordionChange,
+  iconPosition,
   ...other
 }) => {
   const childArray = React.Children.toArray(children);
@@ -30,7 +31,8 @@ const Accordion = ({
           key: i,
           active: activeSectionIndexes.includes(i),
           sectionIndex: i,
-          onAccordionChange: onAccordionChange
+          onAccordionChange,
+          iconPosition
         });
         return section;
       default:
@@ -45,12 +47,15 @@ Accordion.propTypes = {
   /** Used to render AccordionSections inside the Accordion. */
   children: PropTypes.node,
   /** Indexes of the sections that are supposed to be active. */
-  activeSectionIndexes: PropTypes.array
+  activeSectionIndexes: PropTypes.array,
+  /** Where the chevron is positioned in relation to the title */
+  iconPosition: PropTypes.oneOf(['start', 'end'])
 };
 
 Accordion.defaultProps = {
   activeSectionIndexes: [],
-  onAccordionChange: () => {}
+  onAccordionChange: () => {},
+  iconPosition: 'end'
 };
 
 Accordion.displayName = 'Accordion';

--- a/src/Accordion/AccordionSection.js
+++ b/src/Accordion/AccordionSection.js
@@ -20,6 +20,7 @@ const AccordionSection = ({
   active,
   sectionIndex,
   onAccordionChange,
+  iconPosition,
   ...other
 }) => {
   const childArray = React.Children.toArray(children);
@@ -29,17 +30,18 @@ const AccordionSection = ({
         let title;
         title = React.cloneElement(child, {
           key: i,
-          active: active,
-          sectionIndex: sectionIndex,
-          onAccordionChange: onAccordionChange
+          active,
+          sectionIndex,
+          onAccordionChange,
+          iconPosition
         });
         return title;
       case 'AccordionContent':
         let content;
         content = React.cloneElement(child, {
           key: i,
-          active: active,
-          sectionIndex: sectionIndex
+          active,
+          sectionIndex
         });
         return content;
       default:

--- a/src/Accordion/AccordionTitle.js
+++ b/src/Accordion/AccordionTitle.js
@@ -18,6 +18,7 @@ const AccordionTitle = ({
   active,
   sectionIndex,
   onAccordionChange,
+  iconPosition,
   ...other
 }) => {
   const setActiveAccordionIndex = e => {
@@ -28,10 +29,24 @@ const AccordionTitle = ({
     <StyledAccordionTitle
       onClick={setActiveAccordionIndex}
       active={active}
+      iconPosition={iconPosition}
       {...other}
     >
-      <StyledChevronIcon active={`${active}`} />
+      {iconPosition === 'start' ? (
+        <StyledChevronIcon
+          size={16}
+          iconPosition={iconPosition}
+          active={`${active}`}
+        />
+      ) : null}
       {children}
+      {iconPosition === 'end' ? (
+        <StyledChevronIcon
+          size={16}
+          iconPosition={iconPosition}
+          active={`${active}`}
+        />
+      ) : null}
     </StyledAccordionTitle>
   );
 };

--- a/src/Accordion/doc/Accordion.mdx
+++ b/src/Accordion/doc/Accordion.mdx
@@ -117,6 +117,71 @@ import Accordion, {
 
 </Playground>
 
+
+## Icon Position
+
+<Playground>
+  {() => {
+      class AccordionExample extends React.Component {
+        constructor(props) {
+          super(props);
+          this.state = {
+            activeSectionIndexes: [0]
+          };
+
+          this.onAccordionChange = this.onAccordionChange.bind(this);
+        }
+
+        onAccordionChange(evt, index) {
+          this.state.activeSectionIndexes.includes(index)
+            ? this.setState({
+                activeSectionIndexes: this.state.activeSectionIndexes.filter(
+                  item => index !== item
+                )
+              })
+            : this.setState({
+                activeSectionIndexes: [
+                  ...this.state.activeSectionIndexes,
+                  index
+                ]
+              });
+        };
+
+        render() {
+          return (
+            <Accordion
+              iconPosition="start"
+              onAccordionChange={this.onAccordionChange}
+              activeSectionIndexes={this.state.activeSectionIndexes}
+            >
+              <AccordionSection>
+                <AccordionTitle>Accordion Title 1</AccordionTitle>
+                <AccordionContent>
+                  <CalciteP>Accordion Content 1</CalciteP>
+                </AccordionContent>
+              </AccordionSection>
+              <AccordionSection>
+                <AccordionTitle>Accordion Title 2</AccordionTitle>
+                <AccordionContent>
+                  <CalciteP>Accordion Content 2</CalciteP>
+                </AccordionContent>
+              </AccordionSection>
+              <AccordionSection>
+                <AccordionTitle>Accordion Title 3</AccordionTitle>
+                <AccordionContent>
+                  <CalciteP>Accordion Content 3</CalciteP>
+                </AccordionContent>
+              </AccordionSection>
+            </Accordion>
+          );
+        }
+      }
+
+      return <AccordionExample />;
+    }}
+
+</Playground>
+
 ## Props
 
 ### Accordion `default`


### PR DESCRIPTION
## Description
- Update `Accordion` styles to match calcite components
  - Added `iconPosition` prop to control which side of the title the icon will display on
- Padding added to `AccordionContent` will affect styles in apps that don't expect it to have padding by default

## Motivation and Context
Align with latest calcite styling

## Screenshots (if appropriate):
Old:
![Screen Shot 2019-12-20 at 4 13 13 PM](https://user-images.githubusercontent.com/5149922/71298109-aff3e880-2343-11ea-9248-9a98534ecd71.png)

New:
![Screen Shot 2019-12-20 at 4 12 09 PM](https://user-images.githubusercontent.com/5149922/71298089-8e92fc80-2343-11ea-8923-1b5c48024c1c.png)
![Screen Shot 2019-12-20 at 4 12 30 PM](https://user-images.githubusercontent.com/5149922/71298090-8e92fc80-2343-11ea-9f51-a8debb322580.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
