### PR TITLE
Alerts and Toasters

### DIFF
--- a/docz/ThemeWrapper.js
+++ b/docz/ThemeWrapper.js
@@ -1,12 +1,8 @@
 import React from 'react';
 import CalciteThemeProvider from '../src/CalciteThemeProvider';
-import { ToastContainer } from '../src/Toaster';
 
 const ThemeWrapper = ({ children }) => (
-  <CalciteThemeProvider>
-    <ToastContainer />
-    {children}
-  </CalciteThemeProvider>
+  <CalciteThemeProvider>{children}</CalciteThemeProvider>
 );
 
 export default ThemeWrapper;

--- a/package-lock.json
+++ b/package-lock.json
@@ -20279,13 +20279,64 @@
       }
     },
     "react-toastify": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-4.5.1.tgz",
-      "integrity": "sha512-6qWSL7WCwGQ965TgBXYgrxucA85J3CUJRllJ6CHd5+DnA+LJZJAMVUYAOT2rcTMUpcB7pjn3EwknorG2gL7fhA==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-5.4.1.tgz",
+      "integrity": "sha512-24EwkWrj47Id/HGjYfdcntaZpAQ3J5NX31SnGRD66hM/KvPKVJzPiDBPZ+/RZ3SvNkbNWfHpPKFWzenJjC26hg==",
       "requires": {
+        "@babel/runtime": "^7.4.2",
         "classnames": "^2.2.6",
-        "prop-types": "^15.6.0",
-        "react-transition-group": "^2.4.0"
+        "prop-types": "^15.7.2",
+        "react-transition-group": "^4"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.7.7",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.7.tgz",
+          "integrity": "sha512-uCnC2JEVAu8AKB5do1WRIsvrdJ0flYx/A/9f/6chdacnEZ7LmavjdsDXr5ksYBegxtuTPR5Va9/+13QF/kFkCA==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "csstype": {
+          "version": "2.6.8",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.8.tgz",
+          "integrity": "sha512-msVS9qTuMT5zwAGCVm4mxfrZ18BNc6Csd0oJAtiFMZ1FAx1CCvy2+5MDmYoix63LM/6NDbNtodCiGYGmFgO0dA=="
+        },
+        "dom-helpers": {
+          "version": "5.1.3",
+          "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.1.3.tgz",
+          "integrity": "sha512-nZD1OtwfWGRBWlpANxacBEZrEuLa16o1nh7YopFWeoF68Zt8GGEmzHu6Xv4F3XaFIC+YXtTLrzgqKxFgLEe4jw==",
+          "requires": {
+            "@babel/runtime": "^7.6.3",
+            "csstype": "^2.6.7"
+          }
+        },
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          }
+        },
+        "react-transition-group": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.3.0.tgz",
+          "integrity": "sha512-1qRV1ZuVSdxPlPf4O8t7inxUGpdyO5zG9IoNfJxSO0ImU2A1YWkEQvFPuIPZmMLkg5hYs7vv5mMOyfgSkvAwvw==",
+          "requires": {
+            "@babel/runtime": "^7.5.5",
+            "dom-helpers": "^5.0.1",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+        }
       }
     },
     "react-transition-group": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "react-modal": "^3.5.1",
     "react-popper": "^1.3.6",
     "react-resize-aware": "^3.0.0-beta.5",
-    "react-toastify": "^4.3.0",
+    "react-toastify": "^5.4.1",
     "react-transition-group": "^2.4.0",
     "react-virtualized": "^9.20.1",
     "styled-components": "^5.0.0-beta.8",

--- a/src/Alert/Alert-styled.js
+++ b/src/Alert/Alert-styled.js
@@ -13,29 +13,47 @@
 import styled, { css } from 'styled-components';
 
 // Utils, common elements
-import { unitCalc } from '../utils/helpers';
+import { unitCalc, fontSize } from '../utils/helpers';
 import { linkColor } from '../utils/color';
 
 // Calcite theme and Esri colors
 import { CalciteTheme as theme } from '../CalciteThemeProvider';
 
 // Calcite components
-import { CalciteA } from '../Elements';
+import { CalciteA, CalciteP, CalciteH6 } from '../Elements';
 
 // Icons
 
 // Third party libraries
 
+const StyledAlertIcon = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding-left: ${props => props.theme.baseline};
+
+  html[dir='rtl'] & {
+    padding-left: 0;
+    padding-right: ${props => props.theme.baseline};
+  }
+`;
+StyledAlertIcon.defaultProps = { theme };
+
 const StyledAlert = styled.div`
-  padding: ${props => unitCalc(props.theme.baseline, 2, '/')};
-  color: ${props => props.theme.palette.offBlack};
-  background-color: ${props => props.theme.palette.lightestBlue};
+  display: flex;
+  align-items: stretch;
+  color: ${props => props.theme.palette.black};
+  background-color: ${props => props.theme.palette.white};
   position: relative;
   z-index: 100;
   max-width: 40em;
-  border: 1px solid ${props => props.theme.palette.blue};
+  border-top: 3px solid ${props => props.theme.palette.blue};
   box-shadow: ${props => props.theme.boxShadow};
-  border-radius: ${props => props.theme.borderRadius};
+  border-radius: 3px;
+
+  ${StyledAlertIcon} svg {
+    fill: ${props => props.theme.palette.blue};
+  }
 
   ${props =>
     linkColor(props.theme.palette.offBlack, props.theme.palette.black)};
@@ -43,22 +61,31 @@ const StyledAlert = styled.div`
   ${props =>
     props.red &&
     css`
-      background-color: ${props => props.theme.palette.lightestRed};
-      border-color: ${props => props.theme.palette.red};
+      border-top-color: ${props => props.theme.palette.red};
+
+      ${StyledAlertIcon} svg {
+        fill: ${props => props.theme.palette.red};
+      }
     `};
 
   ${props =>
     props.yellow &&
     css`
-      background-color: ${props => props.theme.palette.lightestYellow};
-      border-color: ${props => props.theme.palette.yellow};
+      border-top-color: ${props => props.theme.palette.yellow};
+
+      ${StyledAlertIcon} svg {
+        fill: ${props => props.theme.palette.yellow};
+      }
     `};
 
   ${props =>
     props.green &&
     css`
-      background-color: ${props => props.theme.palette.lightestGreen};
-      border-color: ${props => props.theme.palette.green};
+      border-top-color: ${props => props.theme.palette.green};
+
+      ${StyledAlertIcon} svg {
+        fill: ${props => props.theme.palette.green};
+      }
     `};
 
   ${props =>
@@ -69,24 +96,58 @@ const StyledAlert = styled.div`
 `;
 StyledAlert.defaultProps = { theme };
 
-const StyledAlertClose = styled(CalciteA)`
-  position: absolute;
-  right: ${props => unitCalc(props.theme.baseline, 2, '/')};
-  color: ${props => props.theme.palette.offBlack};
+const StyledAlertContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex: 1 0 auto;
+  padding: ${props => unitCalc(props.theme.baseline, 1.5, '/')}
+    ${props => props.theme.baseline};
+  padding-right: 0;
+`;
+StyledAlertContent.defaultProps = { theme };
 
-  html[dir='rtl'] & {
-    right: auto;
-    left: ${props => unitCalc(props.theme.baseline, 2, '/')};
-  }
+const StyledAlertTitle = styled(CalciteH6)`
+  ${fontSize(-1)};
+  font-weight: 600;
+  margin: 0;
+`;
+StyledAlertTitle.defaultProps = { theme };
+
+const StyledAlertMessage = styled(CalciteP)`
+  ${fontSize(-1)};
+  margin: 0;
+`;
+StyledAlertMessage.defaultProps = { theme };
+
+const StyledAlertClose = styled(CalciteA)`
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  padding: ${props => props.theme.baseline};
+  ${fontSize(-1)};
+  line-height: 0;
 
   &:hover {
     color: ${props => props.theme.palette.black};
+    background: ${props => props.theme.palette.offWhite};
+
+    svg {
+      fill: ${props => props.theme.palette.black};
+    }
   }
 
   svg {
-    fill: currentColor;
+    fill: ${props => props.theme.palette.offBlack};
   }
 `;
 StyledAlertClose.defaultProps = { theme };
 
-export { StyledAlert, StyledAlertClose };
+export {
+  StyledAlert,
+  StyledAlertContent,
+  StyledAlertTitle,
+  StyledAlertMessage,
+  StyledAlertIcon,
+  StyledAlertClose
+};

--- a/src/Alert/Alert-styled.js
+++ b/src/Alert/Alert-styled.js
@@ -66,7 +66,12 @@ const StyledAlert = styled.div`
   ${props =>
     props.red &&
     css`
-      border-color: ${props => props.theme.palette.red};
+      border-left-color: ${props => props.theme.palette.red};
+
+      html[dir='rtl'] & {
+        border-left: none;
+        border-right: 3px solid ${props => props.theme.palette.red};
+      }
 
       ${StyledAlertIcon} svg {
         fill: ${props => props.theme.palette.red};
@@ -76,7 +81,12 @@ const StyledAlert = styled.div`
   ${props =>
     props.yellow &&
     css`
-      border-color: ${props => props.theme.palette.yellow};
+      border-left-color: ${props => props.theme.palette.yellow};
+
+      html[dir='rtl'] & {
+        border-left: none;
+        border-right: 3px solid ${props => props.theme.palette.yellow};
+      }
 
       ${StyledAlertIcon} svg {
         fill: ${props => props.theme.palette.yellow};
@@ -86,7 +96,12 @@ const StyledAlert = styled.div`
   ${props =>
     props.green &&
     css`
-      border-color: ${props => props.theme.palette.green};
+      border-left-color: ${props => props.theme.palette.green};
+
+      html[dir='rtl'] & {
+        border-left: none;
+        border-right: 3px solid ${props => props.theme.palette.green};
+      }
 
       ${StyledAlertIcon} svg {
         fill: ${props => props.theme.palette.green};
@@ -110,8 +125,7 @@ const StyledAlertContent = styled.div`
   padding-right: 0;
 
   html[dir='rtl'] & {
-    padding: ${props => unitCalc(props.theme.baseline, 1.5, '/')}
-      ${props => props.theme.baseline};
+    padding-right: ${props => props.theme.baseline};
     padding-left: 0;
   }
 `;

--- a/src/Alert/Alert-styled.js
+++ b/src/Alert/Alert-styled.js
@@ -47,9 +47,14 @@ const StyledAlert = styled.div`
   position: relative;
   z-index: 100;
   max-width: 40em;
-  border-top: 3px solid ${props => props.theme.palette.blue};
+  border-left: 3px solid ${props => props.theme.palette.blue};
   box-shadow: ${props => props.theme.boxShadow};
-  border-radius: 3px;
+  border-radius: ${props => props.theme.borderRadius};
+
+  html[dir='rtl'] & {
+    border-left: none;
+    border-right: 3px solid ${props => props.theme.palette.blue};
+  }
 
   ${StyledAlertIcon} svg {
     fill: ${props => props.theme.palette.blue};
@@ -61,7 +66,7 @@ const StyledAlert = styled.div`
   ${props =>
     props.red &&
     css`
-      border-top-color: ${props => props.theme.palette.red};
+      border-color: ${props => props.theme.palette.red};
 
       ${StyledAlertIcon} svg {
         fill: ${props => props.theme.palette.red};
@@ -71,7 +76,7 @@ const StyledAlert = styled.div`
   ${props =>
     props.yellow &&
     css`
-      border-top-color: ${props => props.theme.palette.yellow};
+      border-color: ${props => props.theme.palette.yellow};
 
       ${StyledAlertIcon} svg {
         fill: ${props => props.theme.palette.yellow};
@@ -81,7 +86,7 @@ const StyledAlert = styled.div`
   ${props =>
     props.green &&
     css`
-      border-top-color: ${props => props.theme.palette.green};
+      border-color: ${props => props.theme.palette.green};
 
       ${StyledAlertIcon} svg {
         fill: ${props => props.theme.palette.green};
@@ -103,6 +108,12 @@ const StyledAlertContent = styled.div`
   padding: ${props => unitCalc(props.theme.baseline, 1.5, '/')}
     ${props => props.theme.baseline};
   padding-right: 0;
+
+  html[dir='rtl'] & {
+    padding: ${props => unitCalc(props.theme.baseline, 1.5, '/')}
+      ${props => props.theme.baseline};
+    padding-left: 0;
+  }
 `;
 StyledAlertContent.defaultProps = { theme };
 

--- a/src/Alert/Alert.js
+++ b/src/Alert/Alert.js
@@ -52,14 +52,18 @@ const Alert = ({
   };
 
   const getAlertClose = () => {
-    return <StyledAlertClose onClick={onClose}>{closeLabel}</StyledAlertClose>;
+    return (
+      <StyledAlertClose onClick={onClose}>
+        {closeLabel || <XIcon size={16} />}
+      </StyledAlertClose>
+    );
   };
 
   return (
     <StyledAlert blue={blue} green={green} yellow={yellow} red={red} {...other}>
-      {showIcon && getAlertIcon()}
+      {(showIcon || icon) && getAlertIcon()}
       <StyledAlertContent>{children}</StyledAlertContent>
-      {showCloseLabel && getAlertClose()}
+      {(showCloseLabel || closeLabel) && getAlertClose()}
     </StyledAlert>
   );
 };
@@ -90,7 +94,6 @@ Alert.propTypes = {
 };
 
 Alert.defaultProps = {
-  closeLabel: <XIcon size={16} />,
   onClose: () => {}
 };
 

--- a/src/Alert/Alert.js
+++ b/src/Alert/Alert.js
@@ -11,21 +11,55 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import { StyledAlert, StyledAlertClose } from './Alert-styled';
+import {
+  StyledAlert,
+  StyledAlertIcon,
+  StyledAlertContent,
+  StyledAlertClose
+} from './Alert-styled';
 
-const Alert = ({ children, closeLabel, onClose, ...other }) => {
-  const getAlertClose = closeLabel => {
-    if (closeLabel) {
-      return (
-        <StyledAlertClose onClick={onClose}>{closeLabel}</StyledAlertClose>
-      );
+import XIcon from 'calcite-ui-icons-react/XIcon';
+import LightbulbIcon from 'calcite-ui-icons-react/LightbulbIcon';
+import CheckCircleIcon from 'calcite-ui-icons-react/CheckCircleIcon';
+import ExclamationMarkTriangleIcon from 'calcite-ui-icons-react/ExclamationMarkTriangleIcon';
+
+const Alert = ({
+  children,
+  showIcon,
+  icon,
+  showCloseLabel,
+  closeLabel,
+  onClose,
+  blue,
+  green,
+  yellow,
+  red,
+  ...other
+}) => {
+  const getAlertIcon = () => {
+    let defaultIcon;
+    if (green) {
+      defaultIcon = <CheckCircleIcon filled size={16} />;
+    } else if (yellow) {
+      defaultIcon = <ExclamationMarkTriangleIcon filled size={16} />;
+    } else if (red) {
+      defaultIcon = <ExclamationMarkTriangleIcon filled size={16} />;
+    } else {
+      defaultIcon = <LightbulbIcon filled size={16} />;
     }
+
+    return <StyledAlertIcon>{icon || defaultIcon}</StyledAlertIcon>;
+  };
+
+  const getAlertClose = () => {
+    return <StyledAlertClose onClick={onClose}>{closeLabel}</StyledAlertClose>;
   };
 
   return (
-    <StyledAlert {...other}>
-      {children}
-      {getAlertClose(closeLabel)}
+    <StyledAlert blue={blue} green={green} yellow={yellow} red={red} {...other}>
+      {showIcon && getAlertIcon()}
+      <StyledAlertContent>{children}</StyledAlertContent>
+      {showCloseLabel && getAlertClose()}
     </StyledAlert>
   );
 };
@@ -33,6 +67,10 @@ const Alert = ({ children, closeLabel, onClose, ...other }) => {
 Alert.propTypes = {
   /** Components to be rendered within the Alert. */
   children: PropTypes.node,
+  /** Toggles visibility of the icon */
+  showIcon: PropTypes.bool,
+  /** Manually set an icon rather than use the default */
+  icon: PropTypes.node,
   /** Color modifier for the Alert. */
   blue: PropTypes.bool,
   /** Color modifier for the Alert. */
@@ -43,6 +81,8 @@ Alert.propTypes = {
   red: PropTypes.bool,
   /** Full-width modifier for the Alert. */
   full: PropTypes.bool,
+  /**  */
+  showCloseLabel: PropTypes.bool,
   /** Display label used to close the Alert. */
   closeLabel: PropTypes.node,
   /** Callback function fired when the close link is clicked. */
@@ -50,6 +90,7 @@ Alert.propTypes = {
 };
 
 Alert.defaultProps = {
+  closeLabel: <XIcon size={16} />,
   onClose: () => {}
 };
 

--- a/src/Alert/doc/Alert.mdx
+++ b/src/Alert/doc/Alert.mdx
@@ -8,6 +8,7 @@ import GuideExample from '../../../docz/GuideExample';
 
 import Alert, { AlertTitle, AlertMessage } from '../';
 import XIcon from 'calcite-ui-icons-react/XIcon';
+import BananaIcon from 'calcite-ui-icons-react/BananaIcon';
 
 # Alert
 
@@ -62,7 +63,7 @@ import Alert from 'calcite-react/Alert'
     </Alert>
   </GuideExample>
   <GuideExample label='closeLabel="Close"'>
-    <Alert showCloseLabel closeLabel="Close" onClose={() => console.log('clicked')}>
+    <Alert closeLabel="Close" onClose={() => console.log('clicked')}>
       <AlertTitle>Here's a general bit of information</AlertTitle>
       <AlertMessage>Has close link!</AlertMessage>
     </Alert>
@@ -73,25 +74,31 @@ import Alert from 'calcite-react/Alert'
 
 <Playground>
   <GuideExample>
-      <Alert showIcon>
-        <AlertTitle>Here's a general bit of information</AlertTitle>
-        <AlertMessage>Some kind of contextually relevant content</AlertMessage>
-      </Alert>
-    </GuideExample>
+    <Alert showIcon>
+      <AlertTitle>Here's a general bit of information</AlertTitle>
+      <AlertMessage>Some kind of contextually relevant content</AlertMessage>
+    </Alert>
+  </GuideExample>
   <GuideExample>
-      <Alert red showIcon>
-        <AlertTitle>Something failed</AlertTitle>
-        <AlertMessage>That thing you wanted to do didn't work as expected</AlertMessage>
-      </Alert>
-    </GuideExample>
+    <Alert red showIcon>
+      <AlertTitle>Something failed</AlertTitle>
+      <AlertMessage>That thing you wanted to do didn't work as expected</AlertMessage>
+    </Alert>
+  </GuideExample>
   <GuideExample>
-      <Alert yellow showIcon>
-        <AlertMessage>Network connection interruption detected</AlertMessage>
-      </Alert>
-    </GuideExample>
+    <Alert yellow showIcon>
+      <AlertMessage>Network connection interruption detected</AlertMessage>
+    </Alert>
+  </GuideExample>
   <GuideExample>
     <Alert green showIcon>
       <AlertMessage>Successfully duplicated <strong>2019 Sales Demographics by County</strong> layer</AlertMessage>
+    </Alert>
+  </GuideExample>
+  <GuideExample label="icon={<BananaIcon size={16} />}">
+    <Alert icon={<BananaIcon size={16} />}>
+      <AlertTitle>Here's a general bit of information</AlertTitle>
+      <AlertMessage>Some kind of contextually relevant content</AlertMessage>
     </Alert>
   </GuideExample>
 </Playground>

--- a/src/Alert/doc/Alert.mdx
+++ b/src/Alert/doc/Alert.mdx
@@ -6,7 +6,7 @@ route: /alert
 import { Playground, PropsTable } from 'docz';
 import GuideExample from '../../../docz/GuideExample';
 
-import Alert from '../';
+import Alert, { AlertTitle, AlertMessage } from '../';
 import XIcon from 'calcite-ui-icons-react/XIcon';
 
 # Alert
@@ -23,24 +23,76 @@ import Alert from 'calcite-react/Alert'
 
 <Playground>
   <GuideExample>
-    <Alert>Something Happened!</Alert>
-  </GuideExample>
-  <GuideExample label="closeLabel={<XIcon />}">
-    <Alert closeLabel={<XIcon />} onClose={() => console.log('clicked')}>
-      Has close link!
+    <Alert>
+      <AlertTitle>Here's a general bit of information</AlertTitle>
+      <AlertMessage>Some kind of contextually relevant content</AlertMessage>
     </Alert>
   </GuideExample>
   <GuideExample label="red">
-    <Alert red>Something Happened!</Alert>
+    <Alert red>
+      <AlertTitle>Something failed</AlertTitle>
+      <AlertMessage>That thing you wanted to do didn't work as expected</AlertMessage>
+    </Alert>
   </GuideExample>
   <GuideExample label="yellow">
-    <Alert yellow>Something Happened!</Alert>
+    <Alert yellow>
+      <AlertMessage>Network connection interruption detected</AlertMessage>
+    </Alert>
   </GuideExample>
   <GuideExample label="green">
-    <Alert green>Something Happened!</Alert>
+    <Alert green>
+      <AlertMessage>Successfully duplicated <strong>2019 Sales Demographics by County</strong> layer</AlertMessage>
+    </Alert>
   </GuideExample>
   <GuideExample label="full">
-    <Alert full>Something Happened!</Alert>
+    <Alert full>
+      <AlertTitle>Here's a general bit of information</AlertTitle>
+      <AlertMessage>Some kind of contextually relevant content</AlertMessage>
+    </Alert>
+  </GuideExample>
+</Playground>
+
+## Close Action
+
+<Playground>
+  <GuideExample label="showCloseLabel">
+    <Alert showCloseLabel onClose={() => console.log('clicked')}>
+      <AlertTitle>Here's a general bit of information</AlertTitle>
+      <AlertMessage>Has close link!</AlertMessage>
+    </Alert>
+  </GuideExample>
+  <GuideExample label='closeLabel="Close"'>
+    <Alert showCloseLabel closeLabel="Close" onClose={() => console.log('clicked')}>
+      <AlertTitle>Here's a general bit of information</AlertTitle>
+      <AlertMessage>Has close link!</AlertMessage>
+    </Alert>
+  </GuideExample>
+</Playground>
+
+## Icons
+
+<Playground>
+  <GuideExample>
+      <Alert showIcon>
+        <AlertTitle>Here's a general bit of information</AlertTitle>
+        <AlertMessage>Some kind of contextually relevant content</AlertMessage>
+      </Alert>
+    </GuideExample>
+  <GuideExample>
+      <Alert red showIcon>
+        <AlertTitle>Something failed</AlertTitle>
+        <AlertMessage>That thing you wanted to do didn't work as expected</AlertMessage>
+      </Alert>
+    </GuideExample>
+  <GuideExample>
+      <Alert yellow showIcon>
+        <AlertMessage>Network connection interruption detected</AlertMessage>
+      </Alert>
+    </GuideExample>
+  <GuideExample>
+    <Alert green showIcon>
+      <AlertMessage>Successfully duplicated <strong>2019 Sales Demographics by County</strong> layer</AlertMessage>
+    </Alert>
   </GuideExample>
 </Playground>
 

--- a/src/Alert/index.js
+++ b/src/Alert/index.js
@@ -10,3 +10,5 @@
 // limitations under the License.​
 
 export { default } from './Alert';
+export { StyledAlertTitle as AlertTitle } from './Alert-styled';
+export { StyledAlertMessage as AlertMessage } from './Alert-styled';

--- a/src/Alert/index.js
+++ b/src/Alert/index.js
@@ -10,5 +10,7 @@
 // limitations under the License.​
 
 export { default } from './Alert';
-export { StyledAlertTitle as AlertTitle } from './Alert-styled';
-export { StyledAlertMessage as AlertMessage } from './Alert-styled';
+export {
+  StyledAlertTitle as AlertTitle,
+  StyledAlertMessage as AlertMessage
+} from './Alert-styled';

--- a/src/CalciteThemeProvider/CalciteThemeProvider.js
+++ b/src/CalciteThemeProvider/CalciteThemeProvider.js
@@ -12,7 +12,7 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { css, ThemeProvider, createGlobalStyle } from 'styled-components';
-import { unitCalc } from '../utils/helpers';
+import { unitCalc, fontSize } from '../utils/helpers';
 
 import CalciteTheme from './CalciteTheme';
 
@@ -228,30 +228,32 @@ const CalciteReactGlobalStyles = createGlobalStyle`
   .Toastify__toast.Toastify__toast {
     padding: 0.775rem;
     box-shadow: ${CalciteTheme.boxShadow};
-    border: 1px solid ${CalciteTheme.palette.lightestGray};
-    border-radius: ${CalciteTheme.borderRadius};
+    border-top: 3px solid ${CalciteTheme.palette.blue};
+    border-radius: 3px;
     font-family: ${CalciteTheme.type.avenirFamily};
+    color: ${CalciteTheme.palette.offBlack};
+    background: ${CalciteTheme.palette.white};
 
-    &--default {
-      background: ${CalciteTheme.palette.white};
-      color: ${CalciteTheme.palette.offBlack};
-    }
     &--info {
-      background: ${CalciteTheme.palette.blue};
-      border-color: transparent;
+      border-top-color: ${CalciteTheme.palette.blue};
+      background: ${CalciteTheme.palette.white};
     }
     &--success {
-      background: ${CalciteTheme.palette.darkGreen};
-      border-color: transparent;
+      border-top-color: ${CalciteTheme.palette.darkGreen};
+      background: ${CalciteTheme.palette.white};
     }
     &--warning {
-      background: ${CalciteTheme.palette.darkYellow};
-      border-color: transparent;
+      border-top-color: ${CalciteTheme.palette.darkYellow};
+      background: ${CalciteTheme.palette.white};
     }
     &--error {
-      background: ${CalciteTheme.palette.red};
-      border-color: transparent;
+      border-top-color: ${CalciteTheme.palette.red};
+      background: ${CalciteTheme.palette.white};
     }
+  }
+
+  .Toastify__toast .Toastify__toast-body {
+    ${fontSize(-1)};
   }
 
   .Toastify__progress-bar.Toastify__progress-bar {

--- a/src/Toaster/ToastContainer.js
+++ b/src/Toaster/ToastContainer.js
@@ -33,7 +33,7 @@ const ToastContainer = ({ ...other }) => {
     <StyledCloseButton
       type="button"
       iconButton
-      icon={<XIcon size={20} />}
+      icon={<XIcon size={16} />}
       onClick={closeToast}
     />
   );

--- a/src/Toaster/Toaster-styled.js
+++ b/src/Toaster/Toaster-styled.js
@@ -10,19 +10,76 @@
 // limitations under the License.​
 
 // styled-components
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 // Utils, common elements
+import { unitCalc } from '../utils/helpers';
 
 // Calcite theme and Esri colors
 import { CalciteTheme as theme } from '../CalciteThemeProvider';
 
 // Calcite components
+import { StyledAlertContent, StyledAlertIcon } from '../Alert/Alert-styled';
 import Button from '../Button';
 
 // Icons
 
 // Third party libraries
+
+const StyledToaster = styled.div`
+  display: flex;
+
+  ${StyledAlertContent} {
+    flex: 1 0 50%;
+    box-sizing: border-box;
+    padding: ${props => unitCalc(props.theme.baseline, 3, '/')};
+    padding-right: 0;
+  }
+
+  ${StyledAlertIcon} {
+    padding: 0 ${props => unitCalc(props.theme.baseline, 3, '/')};
+
+    /* html[dir='rtl'] & {
+      padding-left: 0;
+      padding-right: ${props => unitCalc(props.theme.baseline, 3, '/')};
+    } */
+
+    svg {
+      fill: ${props => props.theme.palette.blue};
+    }
+  }
+
+  ${props =>
+    props.type === 'error' &&
+    css`
+      border-top-color: ${props => props.theme.palette.red};
+
+      ${StyledAlertIcon} svg {
+        fill: ${props => props.theme.palette.red};
+      }
+    `};
+
+  ${props =>
+    props.type === 'warning' &&
+    css`
+      border-top-color: ${props => props.theme.palette.yellow};
+
+      ${StyledAlertIcon} svg {
+        fill: ${props => props.theme.palette.yellow};
+      }
+    `};
+
+  ${props =>
+    props.type === 'success' &&
+    css`
+      border-top-color: ${props => props.theme.palette.green};
+
+      ${StyledAlertIcon} svg {
+        fill: ${props => props.theme.palette.green};
+      }
+    `};
+`;
+StyledToaster.defaultProps = { theme };
 
 const StyledCloseButton = styled(Button)`
   color: currentColor;
@@ -34,4 +91,4 @@ const StyledCloseButton = styled(Button)`
 `;
 StyledCloseButton.defaultProps = { theme };
 
-export { StyledCloseButton };
+export { StyledToaster, StyledCloseButton };

--- a/src/Toaster/Toaster-styled.js
+++ b/src/Toaster/Toaster-styled.js
@@ -83,10 +83,18 @@ StyledToaster.defaultProps = { theme };
 
 const StyledCloseButton = styled(Button)`
   color: currentColor;
+  margin: -${props => unitCalc(props.theme.baseline, 2, '/')};
+  margin-left: 0;
+  padding: ${props => props.theme.baseline};
+
+  html[dir='rtl'] & {
+    margin-left: ${props => unitCalc(props.theme.baseline, 2, '/')};
+    margin-right: 0;
+  }
 
   &:hover {
     color: currentColor;
-    opacity: 0.7;
+    background: ${props => props.theme.palette.offWhite};
   }
 `;
 StyledCloseButton.defaultProps = { theme };

--- a/src/Toaster/Toaster.js
+++ b/src/Toaster/Toaster.js
@@ -9,11 +9,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.​
 
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import { toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
+
+import { StyledToaster } from './Toaster-styled';
+
+import { StyledAlertContent, StyledAlertIcon } from '../Alert/Alert-styled';
+
+import LightbulbIcon from 'calcite-ui-icons-react/LightbulbIcon';
+import CheckCircleIcon from 'calcite-ui-icons-react/CheckCircleIcon';
+import ExclamationMarkTriangleIcon from 'calcite-ui-icons-react/ExclamationMarkTriangleIcon';
 
 class Toaster extends Component {
   toastId = null;
@@ -30,8 +38,22 @@ class Toaster extends Component {
     }
   }
 
+  getAlertIcon = () => {
+    const { type } = this.props;
+    let defaultIcon;
+    if (type === 'success') {
+      defaultIcon = <CheckCircleIcon filled size={16} />;
+    } else if (type === 'warning' || type === 'error') {
+      defaultIcon = <ExclamationMarkTriangleIcon filled size={16} />;
+    } else {
+      defaultIcon = <LightbulbIcon filled size={16} />;
+    }
+
+    return <StyledAlertIcon>{defaultIcon}</StyledAlertIcon>;
+  };
+
   notify = () => {
-    const { children, showProgress, ...other } = this.props;
+    const { children, type, showProgress, showIcon, ...other } = this.props;
     let progressClassName = '';
     if (showProgress) {
       progressClassName = 'progress-visible';
@@ -40,10 +62,19 @@ class Toaster extends Component {
     }
 
     if (!toast.isActive(this.toastId)) {
-      this.toastId = toast(<Fragment>{children}</Fragment> || '', {
-        progressClassName,
-        ...other
-      });
+      this.toastId = toast(
+        (
+          <StyledToaster type={type}>
+            {showIcon && this.getAlertIcon()}
+            <StyledAlertContent>{children}</StyledAlertContent>
+          </StyledToaster>
+        ) || '',
+        {
+          progressClassName,
+          type,
+          ...other
+        }
+      );
     }
   };
 
@@ -69,7 +100,9 @@ Toaster.propTypes = {
   /** How long the Toaster should be open for; false if it shouldn't auto close, or a duration in millisecnds for how long it should take to close. */
   autoClose: PropTypes.oneOfType([PropTypes.bool, PropTypes.number]),
   /** Toggle default visibility of the progress bar in a Toaster. */
-  showProgress: PropTypes.bool
+  showProgress: PropTypes.bool,
+  /** Toggles visibility of the icon */
+  showIcon: PropTypes.bool
 };
 
 Toaster.defaultProps = {

--- a/src/Toaster/Toaster.js
+++ b/src/Toaster/Toaster.js
@@ -17,66 +17,95 @@ import 'react-toastify/dist/ReactToastify.css';
 
 import { StyledToaster } from './Toaster-styled';
 
-import { StyledAlertContent, StyledAlertIcon } from '../Alert/Alert-styled';
+import {
+  StyledAlertContent,
+  StyledAlertIcon,
+  StyledAlertMessage
+} from '../Alert/Alert-styled';
 
 import LightbulbIcon from 'calcite-ui-icons-react/LightbulbIcon';
 import CheckCircleIcon from 'calcite-ui-icons-react/CheckCircleIcon';
 import ExclamationMarkTriangleIcon from 'calcite-ui-icons-react/ExclamationMarkTriangleIcon';
 
+const getAlertIcon = type => {
+  let defaultIcon;
+  if (type === 'success') {
+    defaultIcon = <CheckCircleIcon filled size={16} />;
+  } else if (type === 'warning' || type === 'error') {
+    defaultIcon = <ExclamationMarkTriangleIcon filled size={16} />;
+  } else {
+    defaultIcon = <LightbulbIcon filled size={16} />;
+  }
+
+  return <StyledAlertIcon>{defaultIcon}</StyledAlertIcon>;
+};
+
+// Wraps the content in a <ToastMessage /> component for styling
+// if they only passed a string of content
+const wrapContentMessage = content => {
+  if (content && typeof content === 'string') {
+    return <StyledAlertMessage>{content}</StyledAlertMessage>;
+  }
+
+  return content;
+};
+
+const notify = (
+  content,
+  { type, showProgress, showIcon, toastId, ...other } = {}
+) => {
+  let progressClassName = '';
+  if (showProgress) {
+    progressClassName = 'progress-visible';
+  } else if (showProgress === false) {
+    progressClassName = 'progress-hidden';
+  }
+
+  if (!toastId || !toast.isActive(toastId)) {
+    toastId = toast(
+      (
+        <StyledToaster type={type}>
+          {showIcon && getAlertIcon(type)}
+          <StyledAlertContent>{wrapContentMessage(content)}</StyledAlertContent>
+        </StyledToaster>
+      ) || '',
+      {
+        progressClassName,
+        type,
+        ...other
+      }
+    );
+  }
+};
+
 class Toaster extends Component {
   toastId = null;
 
   componentDidMount() {
-    if (this.props.open) {
-      this.notify();
+    console.warn(
+      'Depracation warning: Using <Toaster /> as a rendered component is deprecated. Please use notify(content, options). See https://calcite-react.netlify.com/toaster for more info.'
+    );
+
+    const { children, open, ...other } = this.props;
+
+    if (open) {
+      notify(children, {
+        toastId: this.toastId,
+        ...other
+      });
     }
   }
 
   componentDidUpdate(prevProps) {
-    if (this.props.open) {
-      this.notify();
+    const { children, open, ...other } = this.props;
+
+    if (open) {
+      notify(children, {
+        toastId: this.toastId,
+        ...other
+      });
     }
   }
-
-  getAlertIcon = () => {
-    const { type } = this.props;
-    let defaultIcon;
-    if (type === 'success') {
-      defaultIcon = <CheckCircleIcon filled size={16} />;
-    } else if (type === 'warning' || type === 'error') {
-      defaultIcon = <ExclamationMarkTriangleIcon filled size={16} />;
-    } else {
-      defaultIcon = <LightbulbIcon filled size={16} />;
-    }
-
-    return <StyledAlertIcon>{defaultIcon}</StyledAlertIcon>;
-  };
-
-  notify = () => {
-    const { children, type, showProgress, showIcon, ...other } = this.props;
-    let progressClassName = '';
-    if (showProgress) {
-      progressClassName = 'progress-visible';
-    } else if (showProgress === false) {
-      progressClassName = 'progress-hidden';
-    }
-
-    if (!toast.isActive(this.toastId)) {
-      this.toastId = toast(
-        (
-          <StyledToaster type={type}>
-            {showIcon && this.getAlertIcon()}
-            <StyledAlertContent>{children}</StyledAlertContent>
-          </StyledToaster>
-        ) || '',
-        {
-          progressClassName,
-          type,
-          ...other
-        }
-      );
-    }
-  };
 
   render() {
     return null;
@@ -113,4 +142,4 @@ Toaster.defaultProps = {
 
 Toaster.displayName = 'Toaster';
 
-export default Toaster;
+export { Toaster as default, notify };

--- a/src/Toaster/Toaster.js
+++ b/src/Toaster/Toaster.js
@@ -15,7 +15,7 @@ import PropTypes from 'prop-types';
 import { toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 
-import { StyledToaster } from './Toaster-styled';
+import { StyledToaster, StyledCloseButton } from './Toaster-styled';
 
 import {
   StyledAlertContent,
@@ -23,6 +23,8 @@ import {
   StyledAlertMessage
 } from '../Alert/Alert-styled';
 
+// App components
+import XIcon from 'calcite-ui-icons-react/XIcon';
 import LightbulbIcon from 'calcite-ui-icons-react/LightbulbIcon';
 import CheckCircleIcon from 'calcite-ui-icons-react/CheckCircleIcon';
 import ExclamationMarkTriangleIcon from 'calcite-ui-icons-react/ExclamationMarkTriangleIcon';
@@ -50,6 +52,15 @@ const wrapContentMessage = content => {
   return content;
 };
 
+const CloseButton = ({ closeToast }) => (
+  <StyledCloseButton
+    type="button"
+    iconButton
+    icon={<XIcon size={16} />}
+    onClick={closeToast}
+  />
+);
+
 const notify = (
   content,
   { type, showProgress, showIcon, toastId, ...other } = {}
@@ -62,6 +73,11 @@ const notify = (
   }
 
   if (!toastId || !toast.isActive(toastId)) {
+    // If no ToastContainer has been mounted yet we can do that here
+    toast.configure({
+      closeButton: <CloseButton />
+    });
+
     toastId = toast(
       (
         <StyledToaster type={type}>

--- a/src/Toaster/doc/Toaster.mdx
+++ b/src/Toaster/doc/Toaster.mdx
@@ -19,39 +19,10 @@ Calcite React `Toaster` extends the react-toastify library with the `notify` met
 Use `notify(content, options)` to display a toaster notification. View their
 [documentation](https://github.com/fkhadra/react-toastify) to see available options.
 
-#### ⚠️ Important Usage Note ⚠️ 
-
-The `Toaster` requires a supporting component called `ToastContainer` to render properly. 
-Only one `ToastContainer` is allowed per project and should be rendered near the top of
-your component tree.
-```jsx
-import React from 'react';
-import ReactDOM from 'react-dom';
-
-import App from 'path/to/App';
-
-import CalciteThemeProvider from 'calcite-react/CalciteThemeProvider';
-import { ToastContainer, notify } from 'calcite-react/Toaster';
-
-ReactDOM.render(
-  <CalciteThemeProvider>
-    // Create your single ToastContainer for your whole app
-    <ToastContainer />
-    <App>
-      // notify() can be used from any component now
-      <Button onClick={() => notify("Here's a basic toaster!", { showIcon: true })}>
-        Click Me
-      </Button>
-    </App>
-  </CalciteThemeProvider>,
-  document.getElementById('root')
-);
-```
-
-### ⛔️ `Toaster` Component Deprecated ⛔️
+### ⛔️ Use `notify` method ⛔️
 
 We have deprecated using `<Toaster />` as a rendered component and will be removing it
-at our `v1.0.0` release. Please use the newer `notify(content, options);` method to trigger
+at our `v1.0.0` release. Please use the newer `notify(content, options)` method to trigger
 toaster messages.
 
 ## Basic Usage
@@ -386,3 +357,7 @@ export default ToasterExampleComponent;
 ### ToastContainer
 
 <PropsTable of={ToastContainer} />
+
+ℹ️ `ToastContainer` is no longer required unless you are attempting to set
+custom properties for all toast messages in your app. A container will be
+automatically mounted the first time a toast is triggered.

--- a/src/Toaster/doc/Toaster.mdx
+++ b/src/Toaster/doc/Toaster.mdx
@@ -8,7 +8,7 @@ import GuideExample from '../../../docz/GuideExample';
 import { Slide, Zoom, Flip } from 'react-toastify';
 
 import Button from '../../Button';
-import Toaster, {ToastContainer} from '../';
+import Toaster, { ToastContainer, ToastTitle, ToastMessage } from '../';
 
 import ToasterExampleComponent from './ToasterExampleComponent';
 
@@ -122,7 +122,8 @@ ReactDOM.render(
                     open={this.state.toasterOpen}
                     onClose={this.hideToaster}
                   >
-                    Something Happened!
+                    <ToastTitle>Here's a general bit of information</ToastTitle>
+                    <ToastMessage>This toaster will stay open for 10 seconds!</ToastMessage>
                   </Toaster>
                 </GuideExample>
                 <GuideExample label='autoClose={false}'>
@@ -132,7 +133,7 @@ ReactDOM.render(
                     onClose={this.hideToaster2}
                     autoClose={false}
                   >
-                    This toaster won't close automatically!
+                    <ToastMessage>This toaster won't close automatically!</ToastMessage>
                   </Toaster>
                 </GuideExample>
                 <GuideExample label="autoClose={10000}">
@@ -141,8 +142,10 @@ ReactDOM.render(
                     open={this.state.toaster3Open}
                     onClose={this.hideToaster3}
                     autoClose={10000}
+                    showIcon
                   >
-                    This toaster will stay open for 10 seconds!
+                    <ToastTitle>Here's a general bit of information</ToastTitle>
+                    <ToastMessage>This toaster will stay open for 10 seconds!</ToastMessage>
                   </Toaster>
                 </GuideExample>
                 <GuideExample label="showProgress">
@@ -152,7 +155,7 @@ ReactDOM.render(
                     onClose={this.hideToaster4}
                     showProgress
                   >
-                    This toaster has a progress bar!
+                    <ToastMessage>This toaster has a progress bar!</ToastMessage>
                   </Toaster>
                 </GuideExample>
               </div>
@@ -200,42 +203,50 @@ ReactDOM.render(
                 <Button onClick={this.showToaster}>Show Toaster</Button>
                 <Toaster
                   open={this.state.toasterOpen}
+                  showIcon
                   onClose={this.hideToaster}
                   autoClose={false}
                 >
-                  default
+                  <ToastTitle>Here's a general bit of information</ToastTitle>
+                  <ToastMessage>Some kind of contextually relevant content</ToastMessage>
                 </Toaster>
                 <Toaster
                   type="success"
+                  showIcon
                   open={this.state.toasterOpen}
                   onClose={this.hideToaster}
                   autoClose={false}
                 >
-                  success
+                  <ToastMessage>Successfully duplicated <strong>2019 Sales Demographics by County</strong> layer</ToastMessage>
                 </Toaster>
                 <Toaster
                   type="info"
+                  showIcon
                   open={this.state.toasterOpen}
                   onClose={this.hideToaster}
                   autoClose={false}
                 >
-                  info
+                  <ToastTitle>Here's a general bit of information</ToastTitle>
+                  <ToastMessage>Some kind of contextually relevant content</ToastMessage>
                 </Toaster>
                 <Toaster
                   type="warning"
+                  showIcon
                   open={this.state.toasterOpen}
                   onClose={this.hideToaster}
                   autoClose={false}
                 >
-                  warning
+                  <ToastMessage>Network connection interruption detected</ToastMessage>
                 </Toaster>
                 <Toaster
                   type="error"
+                  showIcon
                   open={this.state.toasterOpen}
                   onClose={this.hideToaster}
                   autoClose={false}
                 >
-                  error
+                  <ToastTitle>Something failed</ToastTitle>
+                  <ToastMessage>That thing you wanted to do didn't work as expected</ToastMessage>
                 </Toaster>
               </div>
             </React.Fragment>

--- a/src/Toaster/doc/Toaster.mdx
+++ b/src/Toaster/doc/Toaster.mdx
@@ -4,24 +4,26 @@ route: /toaster
 ---
 
 import { Playground, PropsTable } from 'docz';
+import { Component, Fragment } from 'react';
 import GuideExample from '../../../docz/GuideExample';
 import { Slide, Zoom, Flip } from 'react-toastify';
 
 import Button from '../../Button';
-import Toaster, { ToastContainer, ToastTitle, ToastMessage } from '../';
+import Toaster, { notify, ToastContainer, ToastTitle, ToastMessage } from '../';
 
 import ToasterExampleComponent from './ToasterExampleComponent';
 
 # Toaster
 
-Calcite React `Toaster` extends the react-toastify library. View the
-[documentation](https://github.com/fkhadra/react-toastify) to see available props.
+Calcite React `Toaster` extends the react-toastify library with the `notify` method.
+Use `notify(content, options)` to display a toaster notification. View their
+[documentation](https://github.com/fkhadra/react-toastify) to see available options.
 
 #### ⚠️ Important Usage Note ⚠️ 
 
 The `Toaster` requires a supporting component called `ToastContainer` to render properly. 
-Only one `ToastContainer` is allowed per project and it must be higher in the component
-tree than any of the `Toaster`s you're using.
+Only one `ToastContainer` is allowed per project and should be rendered near the top of
+your component tree.
 ```jsx
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -29,137 +31,113 @@ import ReactDOM from 'react-dom';
 import App from 'path/to/App';
 
 import CalciteThemeProvider from 'calcite-react/CalciteThemeProvider';
-import { ToastContainer } from 'calcite-react/Toaster';
+import { ToastContainer, notify } from 'calcite-react/Toaster';
 
 ReactDOM.render(
   <CalciteThemeProvider>
+    // Create your single ToastContainer for your whole app
     <ToastContainer />
-    <App />
+    <App>
+      // notify() can be used from any component now
+      <Button onClick={() => notify("Here's a basic toaster!", { showIcon: true })}>
+        Click Me
+      </Button>
+    </App>
   </CalciteThemeProvider>,
   document.getElementById('root')
 );
 ```
 
+### ⛔️ `Toaster` Component Deprecated ⛔️
+
+We have deprecated using `<Toaster />` as a rendered component and will be removing it
+at our `v1.0.0` release. Please use the newer `notify(content, options);` method to trigger
+toaster messages.
+
 ## Basic Usage
 
 <Playground>
   {() => {
-      class ToasterStory extends React.Component {
+      class ToasterStory extends Component {
         constructor(props) {
           super(props);
-          this.state = {
-            toasterOpen: false,
-            toaster2Open: false,
-            toaster3Open: false,
-            toaster4Open: false
-          };
 
           this.showToaster = this.showToaster.bind(this);
-          this.hideToaster = this.hideToaster.bind(this);
-          this.showToaster2 = this.showToaster2.bind(this);
-          this.hideToaster2 = this.hideToaster2.bind(this);
-          this.showToaster3 = this.showToaster3.bind(this);
-          this.hideToaster3 = this.hideToaster3.bind(this);
-          this.showToaster4 = this.showToaster4.bind(this);
-          this.hideToaster4 = this.hideToaster4.bind(this);
         }
 
         showToaster() {
-          this.setState({
-            toasterOpen: true
-          });
-        };
-
-        hideToaster() {
-          this.setState({
-            toasterOpen: false
-          });
-        };
-
-        showToaster2() {
-          this.setState({
-            toaster2Open: true
-          });
-        };
-
-        hideToaster2() {
-          this.setState({
-            toaster2Open: false
-          });
-        };
-
-        showToaster3() {
-          this.setState({
-            toaster3Open: true
-          });
-        };
-
-        hideToaster3() {
-          this.setState({
-            toaster3Open: false
-          });
-        };
-
-        showToaster4() {
-          this.setState({
-            toaster4Open: true
-          });
-        };
-
-        hideToaster4() {
-          this.setState({
-            toaster4Open: false
-          });
+          notify((
+            <Fragment>
+              <ToastTitle>Here's a general bit of information</ToastTitle>
+              <ToastMessage>This is a normal toaster</ToastMessage>
+            </Fragment>
+          ))
         };
 
         render() {
           return (
-            <React.Fragment>
-              <div>
-                <GuideExample>
-                  <Button onClick={this.showToaster}>Show Toaster</Button>
-                  <Toaster
-                    open={this.state.toasterOpen}
-                    onClose={this.hideToaster}
-                  >
-                    <ToastTitle>Here's a general bit of information</ToastTitle>
-                    <ToastMessage>This toaster will stay open for 10 seconds!</ToastMessage>
-                  </Toaster>
-                </GuideExample>
-                <GuideExample label='autoClose={false}'>
-                  <Button onClick={this.showToaster2}>Show Toaster</Button>
-                  <Toaster
-                    open={this.state.toaster2Open}
-                    onClose={this.hideToaster2}
-                    autoClose={false}
-                  >
-                    <ToastMessage>This toaster won't close automatically!</ToastMessage>
-                  </Toaster>
-                </GuideExample>
-                <GuideExample label="autoClose={10000}">
-                  <Button onClick={this.showToaster3}>Show Toaster</Button>
-                  <Toaster
-                    open={this.state.toaster3Open}
-                    onClose={this.hideToaster3}
-                    autoClose={10000}
-                    showIcon
-                  >
-                    <ToastTitle>Here's a general bit of information</ToastTitle>
-                    <ToastMessage>This toaster will stay open for 10 seconds!</ToastMessage>
-                  </Toaster>
-                </GuideExample>
-                <GuideExample label="showProgress">
-                  <Button onClick={this.showToaster4}>Show Toaster</Button>
-                  <Toaster
-                    open={this.state.toaster4Open}
-                    onClose={this.hideToaster4}
-                    showProgress
-                  >
-                    <ToastMessage>This toaster has a progress bar!</ToastMessage>
-                  </Toaster>
-                </GuideExample>
-              </div>
-            </React.Fragment>
+            <Button onClick={this.showToaster}>Show Toaster</Button>
+          );
+        }
+      }
+
+      return <ToasterStory />;
+    }}
+
+</Playground>
+
+## AutoClose and Progress Bar
+
+<Playground>
+  {() => {
+      class ToasterStory extends Component {
+        constructor(props) {
+          super(props);
+
+          this.showCustomToaster = this.showCustomToaster.bind(this);
+        }
+
+        showCustomToaster({
+          content,
+          showIcon,
+          autoClose,
+          showProgress
+        }) {
+          notify(content, {
+            showIcon,
+            autoClose,
+            showProgress
+          })
+        };
+
+        render() {
+          return (
+            <Fragment>
+              <GuideExample label='autoClose={false}'>
+                <Button onClick={() => this.showCustomToaster({
+                    content: "This toaster won't close automatically!",
+                    autoClose: false
+                  })}>Show Toaster</Button>
+              </GuideExample>
+              <GuideExample label="autoClose={10000}">
+                <Button onClick={() => this.showCustomToaster({
+                    content: (
+                      <Fragment>
+                        <ToastTitle>Here's a general bit of information</ToastTitle>
+                        <ToastMessage>This toaster will stay open for 10 seconds!</ToastMessage>
+                      </Fragment>
+                    ),
+                    autoClose: 10000,
+                    showIcon: true
+                  })}>Show Toaster</Button>
+              </GuideExample>
+              <GuideExample label="showProgress">
+                <Button onClick={() => this.showCustomToaster({
+                    content: 'This toaster has a progress bar!',
+                    showProgress: true
+                  })}>Show Toaster</Button>
+              </GuideExample>
+            </Fragment>
           );
         }
       }
@@ -173,83 +151,60 @@ ReactDOM.render(
 
 <Playground>
   {() => {
-      class ToasterStory extends React.Component {
+      class ToasterStory extends Component {
         constructor(props) {
           super(props);
-          this.state = {
-            toasterOpen: false
-          };
 
-          this.showToaster = this.showToaster.bind(this);
-          this.hideToaster = this.hideToaster.bind(this);
+          this.showTypeToasters = this.showTypeToasters.bind(this);
         }
 
-        showToaster() {
-          this.setState({
-            toasterOpen: true
+        showTypeToasters() {
+          notify((
+              <Fragment>
+                <ToastTitle>Here's a general bit of information</ToastTitle>
+                <ToastMessage>Some kind of contextually relevant content</ToastMessage>
+              </Fragment>
+            ), {
+            showIcon: true,
+            autoClose: false
           });
-        };
-
-        hideToaster() {
-          this.setState({
-            toasterOpen: false
+          notify((
+              <ToastMessage>Successfully duplicated <strong>2019 Sales Demographics by County</strong> layer</ToastMessage>
+            ), {
+            type: 'success',
+            showIcon: true,
+            autoClose: false
+          });
+          notify((
+              <Fragment>
+                <ToastTitle>Here's a general bit of information</ToastTitle>
+                <ToastMessage>Some kind of contextually relevant content</ToastMessage>
+              </Fragment>
+            ), {
+            type: 'info',
+            showIcon: true,
+            autoClose: false
+          });
+          notify('Network connection interruption detected', {
+            type: 'warning',
+            showIcon: true,
+            autoClose: false
+          });
+          notify((
+              <Fragment>
+                <ToastTitle>Something failed</ToastTitle>
+                <ToastMessage>That thing you wanted to do didn't work as expected</ToastMessage>
+              </Fragment>
+            ), {
+            type: 'error',
+            showIcon: true,
+            autoClose: false
           });
         };
 
         render() {
           return (
-            <React.Fragment>
-              <div>
-                <Button onClick={this.showToaster}>Show Toaster</Button>
-                <Toaster
-                  open={this.state.toasterOpen}
-                  showIcon
-                  onClose={this.hideToaster}
-                  autoClose={false}
-                >
-                  <ToastTitle>Here's a general bit of information</ToastTitle>
-                  <ToastMessage>Some kind of contextually relevant content</ToastMessage>
-                </Toaster>
-                <Toaster
-                  type="success"
-                  showIcon
-                  open={this.state.toasterOpen}
-                  onClose={this.hideToaster}
-                  autoClose={false}
-                >
-                  <ToastMessage>Successfully duplicated <strong>2019 Sales Demographics by County</strong> layer</ToastMessage>
-                </Toaster>
-                <Toaster
-                  type="info"
-                  showIcon
-                  open={this.state.toasterOpen}
-                  onClose={this.hideToaster}
-                  autoClose={false}
-                >
-                  <ToastTitle>Here's a general bit of information</ToastTitle>
-                  <ToastMessage>Some kind of contextually relevant content</ToastMessage>
-                </Toaster>
-                <Toaster
-                  type="warning"
-                  showIcon
-                  open={this.state.toasterOpen}
-                  onClose={this.hideToaster}
-                  autoClose={false}
-                >
-                  <ToastMessage>Network connection interruption detected</ToastMessage>
-                </Toaster>
-                <Toaster
-                  type="error"
-                  showIcon
-                  open={this.state.toasterOpen}
-                  onClose={this.hideToaster}
-                  autoClose={false}
-                >
-                  <ToastTitle>Something failed</ToastTitle>
-                  <ToastMessage>That thing you wanted to do didn't work as expected</ToastMessage>
-                </Toaster>
-              </div>
-            </React.Fragment>
+            <Button onClick={this.showTypeToasters}>Show Toaster</Button>
           );
         }
       }
@@ -263,78 +218,37 @@ ReactDOM.render(
 
 <Playground>
   {() => {
-      class ToasterStory extends React.Component {
+      class ToasterStory extends Component {
         constructor(props) {
           super(props);
-          this.state = {
-            toasterOpen: false
-          };
 
-          this.showToaster = this.showToaster.bind(this);
-          this.hideToaster = this.hideToaster.bind(this);
+          this.showPositionToasters = this.showPositionToasters.bind(this);
         }
 
-        showToaster() {
-          this.setState({
-            toasterOpen: true
+        showPositionToasters() {
+          notify('This toaster is positioned at "top-left"!', {
+            position: 'top-left'
           });
-        };
-
-        hideToaster() {
-          this.setState({
-            toasterOpen: false
+          notify('This toaster is positioned at "top-center"!', {
+            position: 'top-center'
+          });
+          notify('This toaster is positioned at "top-right"!', {
+            position: 'top-right'
+          });
+          notify('This toaster is positioned at "bottom-right"!', {
+            position: 'bottom-right'
+          });
+          notify('This toaster is positioned at "bottom-center"!', {
+            position: 'bottom-center'
+          });
+          notify('This toaster is positioned at "bottom-left"!', {
+            position: 'bottom-left'
           });
         };
 
         render() {
           return (
-            <React.Fragment>
-              <div>
-                <Button onClick={this.showToaster}>Show Toaster</Button>
-                <Toaster
-                  open={this.state.toasterOpen}
-                  onClose={this.hideToaster}
-                  position="top-left"
-                >
-                  This toaster is positioned at "top-left"!
-                </Toaster>
-                <Toaster
-                  open={this.state.toasterOpen}
-                  onClose={this.hideToaster}
-                  position="top-center"
-                >
-                  This toaster is positioned at "top-center"!
-                </Toaster>
-                <Toaster
-                  open={this.state.toasterOpen}
-                  onClose={this.hideToaster}
-                  position="top-right"
-                >
-                  This toaster is positioned at "top-right"!
-                </Toaster>
-                <Toaster
-                  open={this.state.toasterOpen}
-                  onClose={this.hideToaster}
-                  position="bottom-right"
-                >
-                  This toaster is positioned at "bottom-right"!
-                </Toaster>
-                <Toaster
-                  open={this.state.toasterOpen}
-                  onClose={this.hideToaster}
-                  position="bottom-center"
-                >
-                  This toaster is positioned at "bottom-center"!
-                </Toaster>
-                <Toaster
-                  open={this.state.toasterOpen}
-                  onClose={this.hideToaster}
-                  position="bottom-left"
-                >
-                  This toaster is positioned at "bottom-left"!
-                </Toaster>
-              </div>
-            </React.Fragment>
+            <Button onClick={this.showPositionToasters}>Show Toaster</Button>
           );
         }
       }
@@ -348,119 +262,39 @@ ReactDOM.render(
 
 <Playground>
   {() => {
-      class ToasterStory extends React.Component {
+      class ToasterStory extends Component {
         constructor(props) {
           super(props);
-          this.state = {
-            toasterOpen: false,
-            toaster2Open: false,
-            toaster3Open: false,
-            toaster4Open: false
-          };
 
-          this.showToaster = this.showToaster.bind(this);
-          this.hideToaster = this.hideToaster.bind(this);
-          this.showToaster2 = this.showToaster2.bind(this);
-          this.hideToaster2 = this.hideToaster2.bind(this);
-          this.showToaster3 = this.showToaster3.bind(this);
-          this.hideToaster3 = this.hideToaster3.bind(this);
-          this.showToaster4 = this.showToaster4.bind(this);
-          this.hideToaster4 = this.hideToaster4.bind(this);
+          this.showTransitionToaster = this.showTransitionToaster.bind(this);
         }
 
-        showToaster() {
-          this.setState({
-            toasterOpen: true
-          });
-        };
-
-        hideToaster() {
-          this.setState({
-            toasterOpen: false
-          });
-        };
-
-        showToaster2() {
-          this.setState({
-            toaster2Open: true
-          });
-        };
-
-        hideToaster2() {
-          this.setState({
-            toaster2Open: false
-          });
-        };
-
-        showToaster3() {
-          this.setState({
-            toaster3Open: true
-          });
-        };
-
-        hideToaster3() {
-          this.setState({
-            toaster3Open: false
-          });
-        };
-
-        showToaster4() {
-          this.setState({
-            toaster4Open: true
-          });
-        };
-
-        hideToaster4() {
-          this.setState({
-            toaster4Open: false
-          });
+        showTransitionToaster(content, toasterProps) {
+          notify(content, toasterProps);
         };
 
         render() {
           return (
-            <React.Fragment>
-              <div>
-                <GuideExample>
-                  <Button onClick={this.showToaster}>Show Toaster</Button>
-                  <Toaster
-                    open={this.state.toasterOpen}
-                    onClose={this.hideToaster}
-                  >
-                    The Toaster with the Bounce transition!
-                  </Toaster>
-                </GuideExample>
-                <GuideExample label="transition={Slide}">
-                  <Button onClick={this.showToaster2}>Show Toaster</Button>
-                  <Toaster
-                    open={this.state.toaster2Open}
-                    onClose={this.hideToaster2}
-                    transition={Slide}
-                  >
-                    The Toaster with the Slide transition!
-                  </Toaster>
-                </GuideExample>
-                <GuideExample label="transition={Zoom}">
-                  <Button onClick={this.showToaster3}>Show Toaster</Button>
-                  <Toaster
-                    open={this.state.toaster3Open}
-                    onClose={this.hideToaster3}
-                    transition={Zoom}
-                  >
-                    The Toaster with the Zoom transition!
-                  </Toaster>
-                </GuideExample>
-                <GuideExample label="transition={Flip}">
-                  <Button onClick={this.showToaster4}>Show Toaster</Button>
-                  <Toaster
-                    open={this.state.toaster4Open}
-                    onClose={this.hideToaster4}
-                    transition={Flip}
-                  >
-                    The Toaster with the Flip transition!
-                  </Toaster>
-                </GuideExample>
-              </div>
-            </React.Fragment>
+            <Fragment>
+              <GuideExample label="default transition">
+                <Button onClick={() => this.showTransitionToaster('The Toaster with the Bounce transition!')}>Show Toaster</Button>
+              </GuideExample>
+              <GuideExample label="transition={Slide}">
+                <Button onClick={() => this.showTransitionToaster('The Toaster with the Slide transition!', {
+                    transition: Slide
+                  })}>Show Toaster</Button>
+              </GuideExample>
+              <GuideExample label="transition={Zoom}">
+                <Button onClick={() => this.showTransitionToaster('The Toaster with the Zoom transition!', {
+                    transition: Zoom
+                  })}>Show Toaster</Button>
+              </GuideExample>
+              <GuideExample label="transition={Flip}">
+                <Button onClick={() => this.showTransitionToaster('The Toaster with the Flip transition!', {
+                    transition: Flip
+                  })}>Show Toaster</Button>
+              </GuideExample>
+            </Fragment>
           );
         }
       }
@@ -476,7 +310,7 @@ You can use any text, node or component as the content of a `Toaster`. Below is 
 using a custom component with an info icon button to add some more functionality to the
 `Toaster`.
 
-##### ToasterExampleComponent.js
+##### `ToasterExampleComponent.js`
 ```
 import React from 'react';
 import styled from 'styled-components';
@@ -513,45 +347,27 @@ export default ToasterExampleComponent;
 
 <Playground>
   {() => {
-      class ToasterStory extends React.Component {
+      class ToasterStory extends Component {
         constructor(props) {
           super(props);
-          this.state = {
-            toasterOpen: false
-          };
 
           this.showToaster = this.showToaster.bind(this);
-          this.hideToaster = this.hideToaster.bind(this);
         }
 
         showToaster() {
-          this.setState({
-            toasterOpen: true
-          });
-        };
-
-        hideToaster() {
-          this.setState({
-            toasterOpen: false
-          });
+          notify((
+              <ToasterExampleComponent
+                onInfoClick={e => {
+                  alert('info clicked');
+                  e.stopPropagation();
+                }}
+              />
+            ))
         };
 
         render() {
           return (
-            <React.Fragment>
-              <Button onClick={this.showToaster}>Show Toaster</Button>
-              <Toaster
-                open={this.state.toasterOpen}
-                onClose={this.hideToaster}
-              >
-                <ToasterExampleComponent
-                  onInfoClick={e => {
-                    alert('info clicked');
-                    e.stopPropagation();
-                  }}
-                />
-              </Toaster>
-            </React.Fragment>
+            <Button onClick={this.showToaster}>Show Toaster</Button>
           );
         }
       }

--- a/src/Toaster/index.js
+++ b/src/Toaster/index.js
@@ -11,3 +11,7 @@
 
 export { default } from './Toaster';
 export { default as ToastContainer } from './ToastContainer';
+export {
+  StyledAlertTitle as ToastTitle,
+  StyledAlertMessage as ToastMessage
+} from '../Alert/Alert-styled';

--- a/src/Toaster/index.js
+++ b/src/Toaster/index.js
@@ -10,6 +10,7 @@
 // limitations under the License.​
 
 export { default } from './Toaster';
+export { notify } from './Toaster';
 export { default as ToastContainer } from './ToastContainer';
 export {
   StyledAlertTitle as ToastTitle,


### PR DESCRIPTION
## Description
Update `Alert` and `Toaster` to match calcite components styles. Refactor `Toaster` to use `notify` method rather than components.

## Motivation and Context
Keep Calcite React in line with calcite components until we can use their components directly.

## How Has This Been Tested?
In docs

## Screenshots (if appropriate):
### Alert
Before:
![Screen Shot 2020-01-02 at 12 03 01 PM](https://user-images.githubusercontent.com/5149922/71686346-2e935180-2d58-11ea-9c1e-68cada803dc9.png)

After:
![Screen Shot 2020-01-02 at 12 04 56 PM](https://user-images.githubusercontent.com/5149922/71686362-394de680-2d58-11ea-8360-2495fef798c3.png)

### Toaster
Before:
![Screen Shot 2020-01-02 at 12 03 48 PM](https://user-images.githubusercontent.com/5149922/71686384-45d23f00-2d58-11ea-9394-886ab53506b6.png)

After:
![Screen Shot 2020-01-02 at 12 04 46 PM](https://user-images.githubusercontent.com/5149922/71686394-4ec31080-2d58-11ea-8192-9a670c3b6a43.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
