### PR TITLE
Use calcite colors

### DIFF
--- a/docz/DoczCalciteTheme.js
+++ b/docz/DoczCalciteTheme.js
@@ -1,4 +1,4 @@
-import esriColors from './esriColors.json';
+import colors from '@esri/calcite-colors/colors';
 
 export default {
   // Removing logo for now as it overwrites the package name, removing any
@@ -9,34 +9,34 @@ export default {
   // },
   radii: '2px',
   colors: {
-    white: esriColors['blk-000'],
-    grayExtraLight: esriColors['blk-010'],
-    grayLight: esriColors['blk-040'],
-    gray: esriColors['blk-150'],
-    grayDark: esriColors['blk-190'],
-    grayExtraDark: esriColors['blk-210'],
-    dark: esriColors['blk-220'],
-    blue: esriColors['v-bb-160'],
-    skyBlue: esriColors['v-bb-150'],
+    white: colors['blk-000'],
+    grayExtraLight: colors['blk-010'],
+    grayLight: colors['blk-040'],
+    gray: colors['blk-150'],
+    grayDark: colors['blk-190'],
+    grayExtraDark: colors['blk-210'],
+    dark: colors['blk-220'],
+    blue: colors['v-bb-160'],
+    skyBlue: colors['v-bb-150'],
     /** properties below depend on mode select */
-    primary: esriColors['v-bb-160'],
-    text: esriColors['blk-170'],
-    link: esriColors['v-bb-160'],
-    footerText: esriColors['blk-190'],
-    sidebarBg: esriColors['blk-010'],
-    sidebarText: esriColors['blk-170'],
+    primary: colors['v-bb-160'],
+    text: colors['blk-170'],
+    link: colors['v-bb-160'],
+    footerText: colors['blk-190'],
+    sidebarBg: colors['blk-010'],
+    sidebarText: colors['blk-170'],
     sidebarHighlight: null,
-    sidebarBorder: esriColors['blk-060'],
-    background: esriColors['blk-000'],
-    border: esriColors['blk-040'],
-    theadColor: esriColors['blk-150'],
-    theadBg: esriColors['blk-010'],
-    tableColor: esriColors['blk-220'],
-    codeColor: esriColors['blk-150'],
-    preBg: esriColors['blk-010'],
-    blockquoteBg: esriColors['blk-010'],
-    blockquoteBorder: esriColors['blk-040'],
-    blockquoteColor: esriColors['blk-120']
+    sidebarBorder: colors['blk-060'],
+    background: colors['blk-000'],
+    border: colors['blk-040'],
+    theadColor: colors['blk-150'],
+    theadBg: colors['blk-010'],
+    tableColor: colors['blk-220'],
+    codeColor: colors['blk-150'],
+    preBg: colors['blk-010'],
+    blockquoteBg: colors['blk-010'],
+    blockquoteBorder: colors['blk-040'],
+    blockquoteColor: colors['blk-120']
   },
   styles: {
     body: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1213,6 +1213,11 @@
       "integrity": "sha512-n/VQ4mbfr81aqkx/XmVicOLjviMuy02eenSdJY33SVA7S2J42EU0P1H0mOogfYedb3wXA0d/LVtBrgTSm04WEA==",
       "dev": true
     },
+    "@esri/calcite-colors": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-colors/-/calcite-colors-1.7.1.tgz",
+      "integrity": "sha512-oZgYHKPLLfgo4teqDsnS9utYySL5ECYtqkGzXUMOu5J1vSS0Z/MlBEq6RMDm9+aHsDUnMZw6NuXDkaQzwfkzzQ=="
+    },
     "@hutson/parse-repository-url": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@hutson/parse-repository-url/-/parse-repository-url-3.0.2.tgz",
@@ -20289,9 +20294,9 @@
       }
     },
     "react-toastify": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-5.4.1.tgz",
-      "integrity": "sha512-24EwkWrj47Id/HGjYfdcntaZpAQ3J5NX31SnGRD66hM/KvPKVJzPiDBPZ+/RZ3SvNkbNWfHpPKFWzenJjC26hg==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-5.5.0.tgz",
+      "integrity": "sha512-jsVme7jALIFGRyQsri/g4YTsRuaaGI70T6/ikjwZMB4mwTZaCWqj5NqxhGrRStKlJc5npXKKvKeqTiRGQl78LQ==",
       "requires": {
         "@babel/runtime": "^7.4.2",
         "classnames": "^2.2.6",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     ]
   },
   "dependencies": {
+    "@esri/calcite-colors": "^1.7.1",
     "calcite-ui-icons-react": "^0.11.0",
     "downshift": "^3.4.1",
     "match-sorter": "^2.3.0",
@@ -72,7 +73,7 @@
     "react-modal": "^3.11.1",
     "react-popper": "^1.3.6",
     "react-resize-aware": "^3.0.0-beta.5",
-    "react-toastify": "^5.4.1",
+    "react-toastify": "^5.5.0",
     "react-transition-group": "^2.4.0",
     "react-virtualized": "^9.20.1",
     "styled-components": "^5.0.0-beta.8",

--- a/src/Avatar/doc/Avatar.mdx
+++ b/src/Avatar/doc/Avatar.mdx
@@ -8,7 +8,7 @@ import GuideExample from '../../../docz/GuideExample';
 
 import Avatar from '../';
 
-import { EsriColors } from '../../CalciteThemeProvider';
+import colors from '@esri/calcite-colors/colors';
 import CodyProfilePic from './codyProfile.jpeg';
 
 import DownloadToIcon from 'calcite-ui-icons-react/DownloadToIcon';
@@ -34,7 +34,7 @@ import Avatar from 'calcite-react/Avatar'
   <Avatar
     style={{
       margin: '10px',
-      backgroundColor: EsriColors.Calcite_Vibrant_Red_200
+      backgroundColor: colors['v-rr-140']
     }}
   >
     CL
@@ -42,7 +42,7 @@ import Avatar from 'calcite-react/Avatar'
   <Avatar
     style={{
       margin: '10px',
-      backgroundColor: EsriColors.Calcite_Gray_250,
+      backgroundColor: colors['v-bb-140'],
       color: '#4c4c4c'
     }}
   >
@@ -69,7 +69,7 @@ import Avatar from 'calcite-react/Avatar'
   <Avatar
     style={{
       margin: '10px',
-      backgroundColor: EsriColors.Calcite_Green_a100
+      backgroundColor: colors['v-gg-160']
     }}
   >
     <SaveIcon size={16} />
@@ -77,8 +77,8 @@ import Avatar from 'calcite-react/Avatar'
   <Avatar
     style={{
       margin: '10px',
-      backgroundColor: EsriColors.Calcite_Red_150,
-      color: EsriColors.Calcite_Red_a250
+      backgroundColor: colors['v-rr-120'],
+      color: colors['v-rr-160']
     }}
   >
     <UserIcon />
@@ -86,10 +86,10 @@ import Avatar from 'calcite-react/Avatar'
   <Avatar
     style={{
       margin: '10px',
-      backgroundColor: EsriColors.Calcite_Purple_a200
+      backgroundColor: colors['v-vv-160']
     }}
   >
-    <SearchIcon style={{ fill: EsriColors.Calcite_Purple_150 }} />
+    <SearchIcon style={{ fill: colors['v-vv-120'] }} />
   </Avatar>
 </Playground>
 

--- a/src/Button/Button-styled.js
+++ b/src/Button/Button-styled.js
@@ -50,7 +50,8 @@ const StyledButton = styled.button`
   text-decoration: none;
 
   &:hover {
-    background-color: ${props => props.theme.palette.darkBlue};
+    background-color: ${props => props.theme.palette.lightBlue};
+    border-color: ${props => props.theme.palette.lightBlue};
     color: ${props => props.theme.palette.white};
   }
 
@@ -96,18 +97,18 @@ const StyledButton = styled.button`
   ${props =>
     props.isAdornment &&
     css`
-      margin: ${props => unitCalc(props.theme.baseline, 6, '/')} 0 0 0;
+      margin: ${unitCalc(props.theme.baseline, 6, '/')} 0 0 0;
 
       ${props =>
         props.minimal &&
         css`
           background: none;
-          color: ${props => props.theme.linkColor};
+          color: ${props.theme.linkColor};
           border: none;
-          border-bottom: 1px solid ${props => props.theme.palette.lighterGray};
+          border-bottom: 1px solid ${props.theme.palette.lighterGray};
 
           &:hover {
-            color: ${props => props.theme.linkHover};
+            color: ${props.theme.linkHover};
             background: none;
             text-decoration: underline;
           }
@@ -140,11 +141,11 @@ const StyledButton = styled.button`
     props.transparent &&
     css`
       background: none;
-      color: ${props => props.theme.linkColor};
+      color: ${props.theme.linkColor};
       border: none;
 
       &:hover {
-        color: ${props => props.theme.linkHover};
+        color: ${props.theme.linkHover};
         background: none;
         text-decoration: underline;
       }
@@ -160,7 +161,7 @@ const StyledButton = styled.button`
       font-weight: 500;
       white-space: initial;
       user-select: text;
-      color: ${props => props.theme.linkColor};
+      color: ${props.theme.linkColor};
       background-color: transparent;
       position: relative;
       background-image: linear-gradient(currentColor, currentColor),
@@ -221,14 +222,14 @@ const StyledButton = styled.button`
   ${props =>
     props.clear &&
     css`
-      color: ${props => props.theme.palette.blue};
-      background: ${props => props.theme.palette.white};
-      border-color: ${props => props.theme.palette.blue};
+      color: ${props.theme.palette.blue};
+      background: ${props.theme.palette.white};
+      border-color: ${props.theme.palette.blue};
 
       &:hover {
-        color: ${props => props.theme.palette.white};
-        background: ${props => props.theme.palette.darkBlue};
-        border-color: ${props => props.theme.palette.darkBlue};
+        color: ${props.theme.palette.white};
+        background: ${props.theme.palette.darkBlue};
+        border-color: ${props.theme.palette.darkBlue};
       }
     `};
 
@@ -236,11 +237,12 @@ const StyledButton = styled.button`
     props.clearGray &&
     css`
       background: none;
-      color: ${props => props.theme.palette.gray};
-      border-color: ${props => props.theme.palette.gray};
+      color: ${props.theme.palette.gray};
+      border-color: ${props.theme.palette.gray};
       &:hover {
-        color: ${props => props.theme.palette.white};
-        background: ${props => props.theme.palette.darkGray};
+        color: ${props.theme.palette.white};
+        background: ${props.theme.palette.darkGray};
+        border-color: ${props.theme.palette.darkGray};
       }
     `};
 
@@ -248,39 +250,41 @@ const StyledButton = styled.button`
     props.clearWhite &&
     css`
       background: none;
-      color: ${props => props.theme.palette.white};
-      border: 1px solid ${props => props.theme.palette.white};
+      color: ${props.theme.palette.white};
+      border: 1px solid ${props.theme.palette.white};
       &:hover {
-        color: ${props => props.theme.palette.gray};
-        background: ${props => props.theme.palette.white};
+        color: ${props.theme.palette.gray};
+        background: ${props.theme.palette.white};
+        border-color: ${props.theme.palette.white};
       }
     `};
 
   ${props =>
     props.white &&
     css`
-      background: ${props => props.theme.palette.white};
-      color: ${props => props.theme.palette.offBlack};
-      border: 1px solid ${props => props.theme.palette.white};
+      background: ${props.theme.palette.white};
+      color: ${props.theme.palette.offBlack};
+      border: 1px solid ${props.theme.palette.white};
       &:hover {
-        color: ${props => props.theme.palette.offBlack};
-        background: ${props => props.theme.palette.lightestGray};
+        color: ${props.theme.palette.offBlack};
+        background: ${props.theme.palette.lightestGray};
+        border-color: ${props.theme.palette.lightestGray};
       }
     `};
 
   ${props =>
     props.halo &&
     css`
-      color: ${props => props.theme.palette.blue};
+      color: ${props.theme.palette.blue};
       background: transparent;
-      border-color: ${props => props.theme.palette.blue};
-      box-shadow: inset 0 0 0 0 ${props => props.theme.palette.blue};
+      border-color: ${props.theme.palette.blue};
+      box-shadow: inset 0 0 0 0 ${props.theme.palette.blue};
 
       &:hover {
-        color: ${props => props.theme.palette.blue};
+        color: ${props.theme.palette.blue};
         background: transparent;
-        border-color: ${props => props.theme.palette.blue};
-        box-shadow: inset 0 0 0 2px ${props => props.theme.palette.blue};
+        border-color: ${props.theme.palette.blue};
+        box-shadow: inset 0 0 0 2px ${props.theme.palette.blue};
       }
     `};
 
@@ -331,28 +335,28 @@ const StyledButton = styled.button`
   ${props =>
     props.red &&
     css`
-      color: ${props => props.theme.palette.red};
+      color: ${props.theme.palette.red};
       background: transparent;
-      border-color: ${props => props.theme.palette.red};
+      border-color: ${props.theme.palette.red};
 
       &:hover {
-        color: ${props => props.theme.palette.white};
-        background: ${props => props.theme.palette.darkRed};
-        border-color: ${props => props.theme.palette.darkRed};
+        color: ${props.theme.palette.white};
+        background: ${props.theme.palette.darkRed};
+        border-color: ${props.theme.palette.darkRed};
       }
     `};
 
   ${props =>
     props.green &&
     css`
-      color: ${props => props.theme.palette.white};
-      background: ${props => props.theme.palette.green};
-      border-color: ${props => props.theme.palette.green};
+      color: ${props.theme.palette.white};
+      background: ${props.theme.palette.green};
+      border-color: ${props.theme.palette.green};
 
       &:hover {
-        color: ${props => props.theme.palette.white};
-        background: ${props => props.theme.palette.darkGreen};
-        border-color: ${props => props.theme.palette.darkGreen};
+        color: ${props.theme.palette.white};
+        background: ${props.theme.palette.darkGreen};
+        border-color: ${props.theme.palette.darkGreen};
       }
     `};
 
@@ -360,22 +364,22 @@ const StyledButton = styled.button`
     props.iconButton &&
     css`
       background: transparent;
-      color: ${props => props.theme.palette.darkGray};
+      color: ${props.theme.palette.darkGray};
       border: none;
-      padding: ${props => unitCalc(props.theme.baseline, 5, '/')};
+      padding: ${unitCalc(props.theme.baseline, 5, '/')};
       ${props =>
         props.white &&
         css`
-          color: ${props => props.theme.palette.white};
+          color: ${props.theme.palette.white};
         `};
 
       &:hover {
-        color: ${props => props.theme.palette.offBlack};
+        color: ${props.theme.palette.offBlack};
         background: transparent;
         ${props =>
           props.white &&
           css`
-            color: ${props => props.theme.palette.lightestGray};
+            color: ${props.theme.palette.lightestGray};
           `};
       }
     `};
@@ -393,28 +397,28 @@ const StyledButton = styled.button`
 
       &:first-child {
         margin-left: 0;
-        border-top-left-radius: ${props => props.theme.borderRadius};
-        border-bottom-left-radius: ${props => props.theme.borderRadius};
+        border-top-left-radius: ${props.theme.borderRadius};
+        border-bottom-left-radius: ${props.theme.borderRadius};
 
         html[dir='rtl'] & {
           margin-right: 0;
           margin-left: initial;
           border-top-left-radius: 0;
           border-bottom-left-radius: 0;
-          border-top-right-radius: ${props => props.theme.borderRadius};
-          border-bottom-right-radius: ${props => props.theme.borderRadius};
+          border-top-right-radius: ${props.theme.borderRadius};
+          border-bottom-right-radius: ${props.theme.borderRadius};
         }
       }
 
       &:last-child {
-        border-top-right-radius: ${props => props.theme.borderRadius};
-        border-bottom-right-radius: ${props => props.theme.borderRadius};
+        border-top-right-radius: ${props.theme.borderRadius};
+        border-bottom-right-radius: ${props.theme.borderRadius};
 
         html[dir='rtl'] & {
           border-top-right-radius: 0;
           border-bottom-right-radius: 0;
-          border-top-left-radius: ${props => props.theme.borderRadius};
-          border-bottom-left-radius: ${props => props.theme.borderRadius};
+          border-top-left-radius: ${props.theme.borderRadius};
+          border-bottom-left-radius: ${props.theme.borderRadius};
         }
       }
 
@@ -425,7 +429,7 @@ const StyledButton = styled.button`
           cursor: default;
 
           &:hover {
-            background-color: ${props => props.theme.palette.blue};
+            background-color: ${props.theme.palette.blue};
           }
         `};
 

--- a/src/CalciteThemeProvider/CalciteTheme.js
+++ b/src/CalciteThemeProvider/CalciteTheme.js
@@ -9,24 +9,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.​
 
-import EsriColors from './EsriColors';
+import colors from '@esri/calcite-colors/colors';
 
 const CalciteTheme = {
   palette: {
     // ┌───────────┐
     // │ Grayscale │
     // └───────────┘
-    white: '#ffffff',
-    offWhite: EsriColors.Calcite_Gray_100,
-    lightestGray: EsriColors.Calcite_Gray_200,
-    lighterGray: EsriColors.Calcite_Gray_350,
-    lightGray: EsriColors.Calcite_Gray_400,
-    gray: EsriColors.Calcite_Gray_450,
-    darkGray: EsriColors.Calcite_Gray_500,
-    darkerGray: EsriColors.Calcite_Gray_550,
-    darkestGray: EsriColors.Calcite_Gray_600,
-    offBlack: EsriColors.Calcite_Gray_650,
-    black: EsriColors.Calcite_Gray_700,
+    white: colors['blk-000'],
+    offWhite: colors['blk-005'],
+    lightestGray: colors['blk-020'],
+    lighterGray: colors['blk-050'],
+    lightGray: colors['blk-080'],
+    gray: colors['blk-100'],
+    darkGray: colors['blk-120'],
+    darkerGray: colors['blk-140'],
+    darkestGray: colors['blk-160'],
+    offBlack: colors['blk-180'],
+    black: colors['blk-200'],
 
     transparentWhite: 'rgba(255, 255, 255, 0.7)',
     opaqueWhite: 'rgba(255, 255, 255, 0.8)',
@@ -40,52 +40,62 @@ const CalciteTheme = {
     // ┌────────────┐
     // │ Brand Blue │
     // └────────────┘
-    Brand_Blue_100: EsriColors.Brand_Blue_100, //  previously blue 14
-    Brand_Blue_150: EsriColors.Brand_Blue_150, // previously blue 13
-    Brand_Blue_200: EsriColors.Brand_Blue_200, // "Esri Blue", previously blue 12
-    Brand_Blue_250: EsriColors.Brand_Blue_250, // previously blue 11
+    Brand_Blue_100: colors['h-bb-020'], //  previously blue 14
+    Brand_Blue_150: colors['h-bb-040'], // previously blue 13
+    Brand_Blue_200: colors['h-bb-060'], // "Esri Blue", previously blue 12
+    Brand_Blue_250: colors['h-bb-080'], // previously blue 11
 
     // ┌───────────┐
     // │ UI Colors │
     // └───────────┘
-    lightestBlue: EsriColors.Calcite_Blue_100,
-    lighterBlue: EsriColors.Calcite_Blue_150,
-    lightBlue: EsriColors.Calcite_Blue_250,
-    blue: EsriColors.Calcite_Highlight_Blue_350,
-    darkBlue: EsriColors.Calcite_Highlight_Blue_400,
-    darkerBlue: '#052942',
+    lightestBlue: colors['h-bb-010'],
+    lighterBlue: colors['h-bb-030'],
+    lightBlue: colors['h-bb-050'],
+    blue: colors['h-bb-060'],
+    darkBlue: colors['h-bb-080'],
+    darkerBlue: colors['h-bb-100'],
 
-    lightestGreen: EsriColors.Calcite_Green_100,
-    lightGreen: EsriColors.Calcite_Green_150,
-    green: EsriColors.Calcite_Green_250,
-    darkGreen: EsriColors.Calcite_Green_a200,
-    darkGreen200: EsriColors.Calcite_Green_200,
+    lightestGreen: colors['h-gg-010'],
+    lighterGreen: colors['h-gg-020'],
+    lightGreen: colors['h-gg-040'],
+    green: colors['h-gg-060'],
+    darkGreen: colors['h-gg-080'],
+    darkerGreen: colors['h-gg-100'],
 
-    lightestRed: EsriColors.Calcite_Red_100,
-    lightRed: EsriColors.Calcite_Red_150,
-    red: EsriColors.Brand_Red_100,
-    darkRed: EsriColors.Calcite_Red_a200,
-    darkRed200: EsriColors.Calcite_Red_200,
+    lightestRed: colors['h-rr-010'],
+    lighterRed: colors['h-rr-020'],
+    lightRed: colors['h-rr-040'],
+    red: colors['h-rr-060'],
+    darkRed: colors['h-rr-080'],
+    darkerRed: colors['h-rr-100'],
 
-    lightestOrange: EsriColors.Calcite_Orange_a100,
-    lightOrange: EsriColors.Calcite_Orange_a150,
-    orange: EsriColors.Calcite_Orange_a200,
-    darkOrange: EsriColors.Calcite_Orange_a250,
+    lightestOrange: colors['h-oo-010'],
+    lighterOrange: colors['h-oo-020'],
+    lightOrange: colors['h-oo-040'],
+    orange: colors['h-oo-060'],
+    darkOrange: colors['h-oo-080'],
+    darkerOrange: colors['h-oo-100'],
 
-    lightestYellow: EsriColors.Calcite_Yellow_100,
-    lightYellow: EsriColors.Calcite_Yellow_150,
-    yellow: EsriColors.Calcite_Yellow_200,
-    darkYellow: EsriColors.Calcite_Yellow_a150,
+    lightestYellow: colors['h-yy-010'],
+    lighterYellow: colors['h-yy-020'],
+    lightYellow: colors['h-yy-040'],
+    yellow: colors['h-yy-060'],
+    darkYellow: colors['h-yy-080'],
+    darkerYellow: colors['h-yy-100'],
 
-    lightestPurple: EsriColors.Calcite_Purple_100,
-    lightPurple: EsriColors.Calcite_Purple_150,
-    purple: EsriColors.Calcite_Purple_200,
-    darkPurple: EsriColors.Calcite_Purple_a150,
+    lightestPurple: colors['h-vv-010'],
+    lighterPurple: colors['h-vv-020'],
+    lightPurple: colors['h-vv-040'],
+    purple: colors['h-vv-060'],
+    darkPurple: colors['h-vv-080'],
+    darkerPurple: colors['h-vv-100'],
 
-    lightestBrown: EsriColors.Calcite_Brown_100,
-    lightBrown: EsriColors.Calcite_Brown_150,
-    brown: EsriColors.Calcite_Brown_250,
-    darkBrown: EsriColors.Calcite_Brown_a200
+    lightestBrown: colors['h-br-010'],
+    lighterBrown: colors['h-br-020'],
+    lightBrown: colors['h-br-040'],
+    brown: colors['h-br-060'],
+    darkBrown: colors['h-br-080'],
+    darkerBrown: colors['h-br-100']
   },
   type: {
     // Header Family
@@ -133,9 +143,9 @@ const CalciteTheme = {
   // ┌─────────────┐
   // │ Type Colors │
   // └─────────────┘
-  typeColor: EsriColors.Calcite_Gray_650,
-  linkColor: EsriColors.Calcite_Highlight_Blue_350,
-  linkHover: EsriColors.Calcite_Highlight_Blue_400,
+  typeColor: colors['ui-text-1'],
+  linkColor: colors['ui-blue'],
+  linkHover: colors['ui-blue-hover'],
 
   // ┌─────────────┐
   // │ Breakpoints │
@@ -152,7 +162,7 @@ const CalciteTheme = {
   // ┌───────────────────┐
   // │ Tooltip Variables │
   // └───────────────────┘
-  tooltipBackgroundColor: EsriColors.Calcite_Gray_800,
+  tooltipBackgroundColor: colors['blk-200'],
   tooltipBorderRadius: 0,
   tooltipEnterDelay: 0,
 

--- a/src/CalciteThemeProvider/CalciteTheme.js
+++ b/src/CalciteThemeProvider/CalciteTheme.js
@@ -136,7 +136,7 @@ const CalciteTheme = {
   transition: '150ms linear',
   transitionDuration: '150ms',
   easingFunc: 'linear',
-  boxShadow: 'rgba(0, 0, 0, 0.15) 0px 0px 16px 0px;',
+  boxShadow: 'rgba(0, 0, 0, 0.15) 0px 0px 16px 0px',
   drawerWidth: '280px',
   borderRadius: 0,
 

--- a/src/CalciteThemeProvider/CalciteThemeProvider.js
+++ b/src/CalciteThemeProvider/CalciteThemeProvider.js
@@ -239,11 +239,11 @@ const CalciteReactGlobalStyles = createGlobalStyle`
       background: ${CalciteTheme.palette.white};
     }
     &--success {
-      border-top-color: ${CalciteTheme.palette.darkGreen};
+      border-top-color: ${CalciteTheme.palette.green};
       background: ${CalciteTheme.palette.white};
     }
     &--warning {
-      border-top-color: ${CalciteTheme.palette.darkYellow};
+      border-top-color: ${CalciteTheme.palette.yellow};
       background: ${CalciteTheme.palette.white};
     }
     &--error {

--- a/src/Form/Form-styled.js
+++ b/src/Form/Form-styled.js
@@ -124,7 +124,7 @@ const StyledFormHelperText = styled.span`
   ${props =>
     props.success &&
     css`
-      color: ${props => props.theme.palette.darkGreen200};
+      color: ${props => props.theme.palette.darkerGreen};
     `};
 `;
 StyledFormHelperText.defaultProps = { theme };

--- a/src/Loader/doc/Loader.mdx
+++ b/src/Loader/doc/Loader.mdx
@@ -5,7 +5,7 @@ route: /loader
 
 import { Playground, PropsTable } from 'docz';
 import GuideExample from '../../../docz/GuideExample';
-import EsriColors from '../../CalciteThemeProvider/EsriColors';
+import colors from '@esri/calcite-colors/colors';
 
 import Loader from '../';
 
@@ -44,7 +44,7 @@ import Loader from 'calcite-react/Loader'
 <Playground>
   <Loader color="tomato" />
   <Loader color="#1E90FF" />
-  <Loader color={EsriColors.Calcite_Gray_300} />
+  <Loader color={colors['blk-070']} />
 </Playground>
 
 ## Props

--- a/src/Slider/Slider-styled.js
+++ b/src/Slider/Slider-styled.js
@@ -16,7 +16,8 @@ import styled, { css } from 'styled-components';
 import { CalciteInput } from '../utils/commonElements';
 
 // Calcite theme and Esri colors
-import { CalciteTheme as theme, EsriColors } from '../CalciteThemeProvider';
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
+import colors from '@esri/calcite-colors/colors';
 
 // Calcite components
 
@@ -52,7 +53,7 @@ const rangeProps = {
   thumbBgDefault: theme.palette.white,
   thumbBgHover: theme.palette.Brand_Blue_200,
   thumbErrorBgHover: theme.palette.darkRed200,
-  thumbBgActive: EsriColors.Calcite_Blue_a250,
+  thumbBgActive: colors['ui-blue-press'],
   thumbErrorBgActive: theme.palette.darkRed
 };
 

--- a/src/Switch/Switch-styled.js
+++ b/src/Switch/Switch-styled.js
@@ -13,11 +13,12 @@
 import styled, { css } from 'styled-components';
 
 // Utils, common elements
-import { fontSize, unitCalc } from '../utils/helpers';
+import { unitCalc } from '../utils/helpers';
 import { baseRadioCheckbox } from '../utils/commonElements';
 
 // Calcite theme and Esri colors
-import { CalciteTheme as theme, EsriColors } from '../CalciteThemeProvider';
+import { CalciteTheme as theme } from '../CalciteThemeProvider';
+import colors from '@esri/calcite-colors/colors';
 
 // Calcite components
 import { StyledFormControlLabel } from '../Form/Form-styled';
@@ -30,35 +31,32 @@ import { transparentize } from 'polished';
 const switchProps = {
   switchWidth: '36px',
   switchHeight: '20px',
-  switchBg: EsriColors.Calcite_Gray_150,
-  switchBorderColor: EsriColors.Calcite_Gray_350,
-  switchHoverBg: EsriColors.Calcite_Gray_250,
-  switchHoverBorderColor: EsriColors.Calcite_Gray_350,
+  switchBg: colors['blk-010'],
+  switchBorderColor: colors['blk-040'],
+  switchHoverBg: colors['blk-020'],
+  switchHoverBorderColor: colors['blk-060'],
   switchCheckedBg: theme.palette.blue,
   switchCheckedBorderColor: theme.palette.darkBlue,
-  switchFocusShadow: `0 0 4px 2px ${transparentize(
-    0.1,
-    EsriColors.Calcite_Gray_350
-  )}`,
+  switchFocusShadow: `0 0 4px 2px ${transparentize(0.1, colors['blk-050'])}`,
   switchFocusCheckedShadow: `0 0 4px 2px ${transparentize(
     0.1,
-    EsriColors.Calcite_Blue_200
+    colors['h-bb-030']
   )}`,
   switchFocusDestructiveCheckedShadow: `0 0 4px 2px ${transparentize(
     0.1,
-    EsriColors.Calcite_Red_200
+    colors['h-rr-030']
   )}`,
   handleSize: '18px',
   handleTopDistance: '-1px',
   handleEdgeDistance: '-1px',
   handleActiveEdgeDistance: '1px',
   handleBg: theme.palette.white,
-  handleBorderColor: EsriColors.Calcite_Gray_450,
+  handleBorderColor: colors['blk-100'],
   handleShadow: `0 1px 1px 0px ${transparentize(
     0.8,
     theme.palette.darkestGray
   )}`,
-  handleHoverBorderColor: EsriColors.Calcite_Blue_a200,
+  handleHoverBorderColor: colors['h-bb-050'],
   handleHoverShadow: `0 1px 2px 0px ${transparentize(
     0.8,
     theme.palette.darkestGray
@@ -66,10 +64,10 @@ const switchProps = {
   handleCheckedBorderColor: theme.palette.darkBlue,
   handleCheckedShadow: `0 2px 1px 0px {transparentize(.8,CalciteTheme.palette.darkestGray)}`,
   handleActiveShadow: `0 3px 1px 0px {transparentize(.8,CalciteTheme.palette.darkestGray)}`,
-  switchDestructiveCheckedBg: EsriColors.Calcite_Red_a200,
-  switchDestructiveCheckedBorderColor: EsriColors.Calcite_Red_a250,
-  handleDestructiveHoverBorderColor: EsriColors.Calcite_Red_a200,
-  handleDestructiveCheckedBorderColor: EsriColors.Calcite_Red_a250
+  switchDestructiveCheckedBg: colors['h-ro-060'],
+  switchDestructiveCheckedBorderColor: colors['h-ro-070'],
+  handleDestructiveHoverBorderColor: colors['h-ro-060'],
+  handleDestructiveCheckedBorderColor: colors['h-ro-070']
 };
 
 const StyledSwitch = styled.label`

--- a/src/TextField/TextField-styled.js
+++ b/src/TextField/TextField-styled.js
@@ -20,6 +20,8 @@ import { CalciteInput, CalciteTextarea } from '../utils/commonElements';
 import { CalciteTheme as theme } from '../CalciteThemeProvider';
 
 // Calcite components
+import { StyledButton } from '../Button/Button-styled';
+import { StyledSelectInput, StyledSelectButton } from '../Select/Select-styled';
 
 // Icons
 
@@ -95,17 +97,6 @@ const StyledTextArea = styled(CalciteTextarea)`
 `;
 StyledTextArea.defaultProps = { theme };
 
-const StyledTextFieldAdornmentWrapper = styled.div`
-  display: flex;
-
-  ${props =>
-    props.fullWidth &&
-    css`
-      width: 100%;
-    `};
-`;
-StyledTextFieldAdornmentWrapper.defaultProps = { theme };
-
 const StyledAdornmentWrapper = styled.div`
   display: flex;
   align-items: center;
@@ -167,6 +158,27 @@ const StyledAdornmentWrapper = styled.div`
     `};
 `;
 StyledAdornmentWrapper.defaultProps = { theme };
+
+const StyledTextFieldAdornmentWrapper = styled.div`
+  display: flex;
+
+  /* Ensure all adornments and inputs have the same margin with no rounding errors */
+  ${StyledTextField},
+  ${StyledTextArea},
+  ${StyledButton},
+  ${StyledAdornmentWrapper},
+  ${StyledSelectInput},
+  ${StyledSelectButton} {
+    margin: ${props => unitCalc(props.theme.baseline, 6, '/')} 0 0 0;
+  }
+
+  ${props =>
+    props.fullWidth &&
+    css`
+      width: 100%;
+    `};
+`;
+StyledTextFieldAdornmentWrapper.defaultProps = { theme };
 
 export {
   StyledTextField,

--- a/src/TextField/doc/TextField.mdx
+++ b/src/TextField/doc/TextField.mdx
@@ -110,7 +110,7 @@ import TextField from 'calcite-react/TextField'
           <TextField
             defaultValue="500.00"
             rightAdornment={
-              <Select placement="bottom-end" selectedValue="usd">
+              <Select id="currencyUnitSelect" placement="bottom-end" selectedValue="usd">
                 <MenuItem value="usd">USD</MenuItem>
                 <MenuItem value="eur">EUR</MenuItem>
                 <MenuItem value="jpy">JPY</MenuItem>

--- a/src/Toaster/Toaster.js
+++ b/src/Toaster/Toaster.js
@@ -74,9 +74,12 @@ const notify = (
 
   if (!toastId || !toast.isActive(toastId)) {
     // If no ToastContainer has been mounted yet we can do that here
-    toast.configure({
-      closeButton: <CloseButton />
-    });
+    if (!document.getElementsByClassName('Toastify')) {
+      toast.configure({
+        className: 'calcite-react-toastify',
+        closeButton: <CloseButton />
+      });
+    }
 
     toastId = toast(
       (

--- a/src/Toaster/doc/Toaster.mdx
+++ b/src/Toaster/doc/Toaster.mdx
@@ -6,12 +6,15 @@ route: /toaster
 import { Playground, PropsTable } from 'docz';
 import { Component, Fragment } from 'react';
 import GuideExample from '../../../docz/GuideExample';
-import { Slide, Zoom, Flip } from 'react-toastify';
+import { toast, Slide, Zoom, Flip } from 'react-toastify';
 
 import Button from '../../Button';
 import Toaster, { notify, ToastContainer, ToastTitle, ToastMessage } from '../';
 
 import ToasterExampleComponent from './ToasterExampleComponent';
+
+import { StyledCloseButton } from '../Toaster-styled';
+import XIcon from 'calcite-ui-icons-react/XIcon';
 
 # Toaster
 
@@ -32,6 +35,18 @@ toaster messages.
       class ToasterStory extends Component {
         constructor(props) {
           super(props);
+          const CloseButton = ({ closeToast }) => (
+            <StyledCloseButton
+              type="button"
+              iconButton
+              icon={<XIcon size={16} />}
+              onClick={closeToast}
+            />
+          );
+
+          toast.configure({
+            closeButton: <CloseButton />
+          });
 
           this.showToaster = this.showToaster.bind(this);
         }


### PR DESCRIPTION
## Description
Added `@esri/calcite-colors` and updated theme to use those colors. Should be minimal impact on component look and feel.

Green is the largest change...
Before:
![Screen Shot 2020-01-07 at 3 27 52 PM](https://user-images.githubusercontent.com/5149922/71934736-53296800-3162-11ea-8410-7757be7f36ef.png)

After:
![Screen Shot 2020-01-07 at 3 27 59 PM](https://user-images.githubusercontent.com/5149922/71934749-57558580-3162-11ea-91a9-0928e5f37bc8.png)

Also snuck in a quick fix for `ToastContainer` and `TextFields` with adornments

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
