### PR TITLE
v0.47.2

### DIFF
--- a/src/Modal/Modal-styled.js
+++ b/src/Modal/Modal-styled.js
@@ -99,6 +99,7 @@ const StyledModalHeader = styled.div`
 StyledModalHeader.defaultProps = { theme };
 
 const StyledModalTitle = styled(CalciteH3)`
+  width: 100%;
   margin: 0;
   padding: ${props => unitCalc(props.theme.baseline, 2, '/')}
     ${props => props.theme.baseline};

--- a/src/Modal/Modal.js
+++ b/src/Modal/Modal.js
@@ -31,6 +31,7 @@ import {
 const Modal = ({
   children,
   open,
+  contentLabel,
   title,
   overlayStyle,
   dialogStyle,
@@ -66,7 +67,7 @@ const Modal = ({
               ...dialogTransition[state]
             }
           }}
-          contentLabel={title}
+          contentLabel={contentLabel}
           role="dialog"
           onRequestClose={onRequestClose}
           {...other}
@@ -101,8 +102,10 @@ Modal.propTypes = {
   children: PropTypes.node,
   /** Boolean describing if the Modal should be shown or not. */
   open: PropTypes.bool,
+  /** Node to be rendered as the modal title in the header */
+  title: PropTypes.node,
   /** String indicating how the content container should be announced to screenreaders. */
-  title: PropTypes.string,
+  contentLabel: PropTypes.string,
   /** Buttons or links to be placed in the Modal actions footer. */
   actions: PropTypes.node,
   /** Buttons or links to be placed in the footer, opposite your primary actions. */


### PR DESCRIPTION
## Description
- Allow `Modal` `title` prop to take a node rather than just a string. Allows for some extra styling options.

## Motivation and Context
Need some styling control in A4IoT to add an action button to the header.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
