### PR TITLE
v0.47.5

### DIFF
--- a/docz/DoczCalciteTheme.js
+++ b/docz/DoczCalciteTheme.js
@@ -1,4 +1,4 @@
-import colors from '@esri/calcite-colors/colors';
+import colors from '@esri/calcite-colors/colors.json';
 
 export default {
   // Removing logo for now as it overwrites the package name, removing any

--- a/src/Avatar/doc/Avatar.mdx
+++ b/src/Avatar/doc/Avatar.mdx
@@ -8,7 +8,7 @@ import GuideExample from '../../../docz/GuideExample';
 
 import Avatar from '../';
 
-import colors from '@esri/calcite-colors/colors';
+import colors from '@esri/calcite-colors/colors.json';
 import CodyProfilePic from './codyProfile.jpeg';
 
 import DownloadToIcon from 'calcite-ui-icons-react/DownloadToIcon';

--- a/src/CalciteThemeProvider/CalciteTheme.js
+++ b/src/CalciteThemeProvider/CalciteTheme.js
@@ -9,7 +9,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.​
 
-import colors from '@esri/calcite-colors/colors';
+import colors from '@esri/calcite-colors/colors.json';
 
 const CalciteTheme = {
   palette: {

--- a/src/Loader/doc/Loader.mdx
+++ b/src/Loader/doc/Loader.mdx
@@ -5,7 +5,7 @@ route: /loader
 
 import { Playground, PropsTable } from 'docz';
 import GuideExample from '../../../docz/GuideExample';
-import colors from '@esri/calcite-colors/colors';
+import colors from '@esri/calcite-colors/colors.json';
 
 import Loader from '../';
 

--- a/src/Slider/Slider-styled.js
+++ b/src/Slider/Slider-styled.js
@@ -17,7 +17,7 @@ import { CalciteInput } from '../utils/commonElements';
 
 // Calcite theme and Esri colors
 import { CalciteTheme as theme } from '../CalciteThemeProvider';
-import colors from '@esri/calcite-colors/colors';
+import colors from '@esri/calcite-colors/colors.json';
 
 // Calcite components
 

--- a/src/Switch/Switch-styled.js
+++ b/src/Switch/Switch-styled.js
@@ -18,7 +18,7 @@ import { baseRadioCheckbox } from '../utils/commonElements';
 
 // Calcite theme and Esri colors
 import { CalciteTheme as theme } from '../CalciteThemeProvider';
-import colors from '@esri/calcite-colors/colors';
+import colors from '@esri/calcite-colors/colors.json';
 
 // Calcite components
 import { StyledFormControlLabel } from '../Form/Form-styled';


### PR DESCRIPTION
## Description
Update reference to `@esri/calcite-colors` to use the `.json` file.

## Motivation and Context
Should fix the problem in Jest where the non transpiled .js file was causing tests to fail.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
