### PR TITLE
ActionBar position, ArcGIS Share and ComboButton

### DIFF
--- a/src/ActionBar/Action.js
+++ b/src/ActionBar/Action.js
@@ -31,6 +31,7 @@ const Action = ({ children, icon, ...other }) => {
     <StyledAction
       dark={actionBarContext.dark}
       collapsed={actionBarContext.collapsed}
+      position={actionBarContext.position}
       icon={getIcon(icon)}
       {...other}
     >
@@ -41,7 +42,7 @@ const Action = ({ children, icon, ...other }) => {
   return actionBarContext.collapsed ? (
     <Tooltip
       title={children}
-      placement="right"
+      placement={actionBarContext.position === 'start' ? 'right' : 'left'}
       targetWrapperStyle={TooltipWrapperStyles}
     >
       {actionButton}

--- a/src/ActionBar/ActionBar-styled.js
+++ b/src/ActionBar/ActionBar-styled.js
@@ -136,9 +136,29 @@ const StyledCollapseAction = styled(Button).attrs(({ collapsed }) => {
     flex-shrink: 0;
     margin-left: 0 !important;
 
+    ${props =>
+      props.position === 'end' &&
+      css`
+        transform: rotate(180deg);
+      `};
+
     html[dir='rtl'] & {
-      margin-left: ${props => unitCalc(props.theme.baseline, 2, '/')};
+      margin-left: ${props =>
+        unitCalc(props.theme.baseline, 2, '/')} !important;
       margin-right: 0 !important;
+      transform: rotate(180deg);
+
+      ${props =>
+        props.position === 'end' &&
+        css`
+          transform: rotate(0deg);
+        `};
+
+      ${props =>
+        props.collapsed &&
+        css`
+          margin-left: 0 !important;
+        `};
     }
   }
 `;
@@ -183,6 +203,10 @@ const StyledAction = styled(StyledCollapseAction)`
           }
         }
       `};
+  }
+
+  svg {
+    transform: rotate(0deg) !important;
   }
 `;
 

--- a/src/ActionBar/ActionBar.js
+++ b/src/ActionBar/ActionBar.js
@@ -72,7 +72,7 @@ ActionBar.propTypes = {
   /** Style prop to render a dark ActionBar. */
   dark: PropTypes.bool,
   /** Adjust alignment so ActionBar can be placed on the right side of the screen. */
-  right: PropTypes.oneOf(['start', 'end']),
+  position: PropTypes.oneOf(['start', 'end']),
   /** Toggle visibility of the collapser control at the bottom of the ActionBar */
   showCollapser: PropTypes.bool,
   /** Programatically control collapsed state of the ActionBar */

--- a/src/ActionBar/ActionBar.js
+++ b/src/ActionBar/ActionBar.js
@@ -22,6 +22,7 @@ import CollapseAction from './CollapseAction';
 
 const ActionBarContext = createContext({
   dark: undefined,
+  position: undefined,
   collapsed: undefined
 });
 ActionBarContext.displayName = 'ActionBarContext';
@@ -29,6 +30,7 @@ ActionBarContext.displayName = 'ActionBarContext';
 const ActionBar = ({
   children,
   dark,
+  position,
   showCollapser,
   collapsed,
   collapseLabel,
@@ -36,16 +38,22 @@ const ActionBar = ({
   onToggleCollapse,
   ...other
 }) => {
-  const actionBarContext = useContextState({ dark, collapsed });
+  const actionBarContext = useContextState({ dark, position, collapsed });
 
   return (
     <ActionBarContext.Provider value={actionBarContext}>
-      <StyledActionBar dark={dark} collapsed={collapsed} {...other}>
+      <StyledActionBar
+        dark={dark}
+        position={position}
+        collapsed={collapsed}
+        {...other}
+      >
         {children}
         {showCollapser && (
           <StyledActionBarCollapseContainer>
             <CollapseAction
               dark={dark}
+              position={position}
               collapsed={collapsed}
               collapseLabel={collapseLabel}
               expandLabel={expandLabel}
@@ -63,6 +71,8 @@ ActionBar.propTypes = {
   children: PropTypes.node,
   /** Style prop to render a dark ActionBar. */
   dark: PropTypes.bool,
+  /** Adjust alignment so ActionBar can be placed on the right side of the screen. */
+  right: PropTypes.oneOf(['start', 'end']),
   /** Toggle visibility of the collapser control at the bottom of the ActionBar */
   showCollapser: PropTypes.bool,
   /** Programatically control collapsed state of the ActionBar */
@@ -76,6 +86,7 @@ ActionBar.propTypes = {
 };
 
 ActionBar.defaultProps = {
+  position: 'start',
   showCollapser: true,
   collapseLabel: 'Collapse',
   expandLabel: 'Expand',

--- a/src/ActionBar/CollapseAction.js
+++ b/src/ActionBar/CollapseAction.js
@@ -25,6 +25,7 @@ const CollapseAction = ({
   expandLabel,
   collapseLabel,
   dark,
+  position,
   ...other
 }) => {
   const getAction = action => {
@@ -35,7 +36,7 @@ const CollapseAction = ({
     return (
       <Tooltip
         title={expandLabel}
-        placement="right"
+        placement={position === 'start' ? 'right' : 'left'}
         targetWrapperStyle={TooltipWrapperStyles}
       >
         {action}
@@ -49,6 +50,7 @@ const CollapseAction = ({
         collapsed ? <ChevronsRight size={16} /> : <ChevronsLeft size={16} />
       }
       dark={dark}
+      position={position}
       {...other}
     >
       {!collapsed && collapseLabel}

--- a/src/ActionBar/doc/ActionBar.mdx
+++ b/src/ActionBar/doc/ActionBar.mdx
@@ -45,7 +45,7 @@ import ActionBar, {
 
 ## Controlled ActionBar
 
-<Playground style={{height: '400px', background: "#f3f3f3"}}>
+<Playground style={{height: '400px', background: "#f3f3f3", display: 'flex'}}>
   {() => {    
       class ActionBarStory extends React.Component {
         constructor(props) {
@@ -141,6 +141,16 @@ import ActionBar, {
     <BottomActionGroup>
       <Action icon={<SignOutIcon />}>Sign Out</Action>
     </BottomActionGroup>
+  </ActionBar>
+</Playground>
+
+## Position "end"
+
+<Playground style={{height: '400px', background: "#f3f3f3", display: 'flex', justifyContent: 'flex-end'}}>
+  <ActionBar position="end">
+    <Action active icon={<PlusIcon />}>Add Item</Action>
+    <Action icon={<SaveIcon />}>Save</Action>
+    <Action icon={<LayersIcon filled />}>Layer List</Action>
   </ActionBar>
 </Playground>
 

--- a/src/ArcgisShare/ArcgisShare.js
+++ b/src/ArcgisShare/ArcgisShare.js
@@ -143,33 +143,42 @@ class ArcgisShare extends Component {
       publicLabel,
       groupsLabel,
       noGroupsLabel,
+      hidePublicSharing,
+      hideOrganizationSharing,
+      hideGroupsSharing,
       portal,
       user
     } = this.props;
 
     return (
       <StyledArcgisShare>
-        <Checkbox
-          labelStyle={{ ...PrimaryCheckboxLabelStyles }}
-          checked={this.state.public || false}
-          onChange={this.publicChange}
-        >
-          {publicLabel}
-        </Checkbox>
-        <Checkbox
-          labelStyle={{ ...PrimaryCheckboxLabelStyles }}
-          checked={this.state.org || this.state.public || false}
-          onChange={this.orgChange}
-          disabled={this.state.public || false}
-        >
-          {portal && portal.name}
-        </Checkbox>
-        <StyledGroupFieldset name="shareGroups">
-          <StyledLegend>{groupsLabel}:</StyledLegend>
-          <StyledGroupContainer>
-            {user && this.getGroupCheckboxes(user.groups, noGroupsLabel)}
-          </StyledGroupContainer>
-        </StyledGroupFieldset>
+        {!hidePublicSharing ? (
+          <Checkbox
+            labelStyle={{ ...PrimaryCheckboxLabelStyles }}
+            checked={this.state.public || false}
+            onChange={this.publicChange}
+          >
+            {publicLabel}
+          </Checkbox>
+        ) : null}
+        {!hideOrganizationSharing ? (
+          <Checkbox
+            labelStyle={{ ...PrimaryCheckboxLabelStyles }}
+            checked={this.state.org || this.state.public || false}
+            onChange={this.orgChange}
+            disabled={this.state.public || false}
+          >
+            {portal && portal.name}
+          </Checkbox>
+        ) : null}
+        {!hideGroupsSharing ? (
+          <StyledGroupFieldset name="shareGroups">
+            <StyledLegend>{groupsLabel}:</StyledLegend>
+            <StyledGroupContainer>
+              {user && this.getGroupCheckboxes(user.groups, noGroupsLabel)}
+            </StyledGroupContainer>
+          </StyledGroupFieldset>
+        ) : null}
       </StyledArcgisShare>
     );
   }
@@ -182,6 +191,12 @@ ArcgisShare.propTypes = {
   portal: PropTypes.object.isRequired,
   /** AGOL sharing object. */
   sharing: PropTypes.object,
+  /** Hide the option to share publically. */
+  hidePublicSharing: PropTypes.bool,
+  /** Hide the option to share to your organization. */
+  hideOrganizationSharing: PropTypes.bool,
+  /** Hide the option to share with your groups. */
+  hideGroupsSharing: PropTypes.bool,
   /** Text label for the Public group. */
   publicLabel: PropTypes.string,
   /** Text label for the Groups header. */
@@ -195,7 +210,10 @@ ArcgisShare.propTypes = {
 ArcgisShare.defaultProps = {
   publicLabel: 'Everyone (public)',
   groupsLabel: 'These groups',
-  noGroupsLabel: 'No groups for this user'
+  noGroupsLabel: 'No groups for this user',
+  hidePublicSharing: false,
+  hideOrganizationSharing: false,
+  hideGroupsSharing: false
 };
 
 ArcgisShare.displayName = 'ArcgisShare';

--- a/src/ArcgisShare/doc/ArcgisShare.mdx
+++ b/src/ArcgisShare/doc/ArcgisShare.mdx
@@ -61,6 +61,17 @@ import ArcgisShare from 'calcite-react/ArcgisShare'
   />
 </Playground>
 
+## Hide Public Sharing
+
+<Playground>
+  <ArcgisShare
+    user={user}
+    portal={portal}
+    hidePublicSharing
+    onChange={e => console.log(e)}
+  />
+</Playground>
+
 ## Props
 
 <PropsTable of={ArcgisShare} />

--- a/src/CalciteThemeProvider/CalciteThemeProvider.js
+++ b/src/CalciteThemeProvider/CalciteThemeProvider.js
@@ -253,7 +253,7 @@ const CalciteReactGlobalStyles = createGlobalStyle`
   }
 
   .Toastify__toast .Toastify__toast-body {
-    ${fontSize(-1)};
+    ${() => fontSize(-1)};
   }
 
   .Toastify__progress-bar.Toastify__progress-bar {

--- a/src/ComboButton/ComboButton.js
+++ b/src/ComboButton/ComboButton.js
@@ -43,6 +43,7 @@ class ComboButton extends Component {
       iconPosition,
       dropdownIcon,
       half,
+      closeOnSelect,
       ...other
     } = this.props;
 
@@ -70,6 +71,7 @@ class ComboButton extends Component {
         <Popover
           open={this.state.open}
           onRequestClose={this.closePopover}
+          closeOnSelect={closeOnSelect}
           placement="bottom-end"
           targetContainerStyles={{ display: 'block' }}
           targetEl={
@@ -121,12 +123,15 @@ ComboButton.propTypes = {
   /** The position of the icon in relation to other children in a ComboButton. */
   iconPosition: PropTypes.oneOf(['after', 'before']),
   /** The icon used inside the dropdown button */
-  dropdownIcon: PropTypes.node
+  dropdownIcon: PropTypes.node,
+  /** Whether or not the Popover should trigger onRequestClose when an element is selected. */
+  closeOnSelect: PropTypes.bool
 };
 
 ComboButton.defaultProps = {
   type: 'button',
   iconPosition: 'after',
+  closeOnSelect: true,
   dropdownIcon: <CaretDownIcon filled size={14} />,
   onClick: () => {}
 };


### PR DESCRIPTION
## Description
- Add `position` prop to `ActionBar`
- Add ability to hide some sharing options in `ArcgisShare`
- Close `ComboButton` popover when an option is selected

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
