### PR TITLE
Small Stepper enhancements

### DIFF
--- a/src/Stepper/Step.js
+++ b/src/Stepper/Step.js
@@ -53,7 +53,7 @@ const Step = ({
   });
 
   return (
-    <StyledStep vertical={vertical} {...other}>
+    <StyledStep vertical={vertical} small={small} {...other}>
       <StepIcon
         icon={icon}
         active={active}

--- a/src/Stepper/Stepper-styled.js
+++ b/src/Stepper/Stepper-styled.js
@@ -61,8 +61,19 @@ const StyledStep = styled.div`
       flex: unset;
       align-items: flex-start;
       margin-right: 0;
-      margin-bottom: ${props => unitCalc(props.theme.baseline, 2, '/')};
-      padding-bottom: ${props => props.theme.baseline};
+      margin-bottom: ${unitCalc(props.theme.baseline, 2, '/')};
+      padding-bottom: ${props.theme.baseline};
+
+      ${props =>
+        props.small &&
+        css`
+          margin-bottom: ${unitCalc(props.theme.baseline, 4, '/')};
+          padding-bottom: ${unitCalc(props.theme.baseline, 3, '/')};
+
+          ${StyledStepDescription} {
+            line-height: 1.25rem;
+          }
+        `};
 
       html[dir='rtl'] & {
         margin-left: 0;
@@ -253,6 +264,12 @@ const StyledStepIcon = styled.div`
             background: ${props => props.theme.palette.blue};
           `};
       }
+
+      ${props =>
+        props.small &&
+        css`
+          padding-bottom: ${props => unitCalc(props.theme.baseline, 4, '/')};
+        `};
 
       *:last-of-type > &::after {
         content: none;


### PR DESCRIPTION
## Description
Originally `small` `Stepper` was meant to hide the description text to save space, this enhances the styles so that the description text can be rendered in a smaller area now.

## Motivation and Context
Context is lost when description text is hidden, this will allow us to save space and still keep informational text throughout our apps.

## Screenshots (if appropriate):
![Screen Shot 2020-03-11 at 4 39 43 PM](https://user-images.githubusercontent.com/5149922/76473862-07d84380-63b7-11ea-9503-4f7a24cff1dc.png)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
