### PR TITLE
Checkbox width

### DIFF
--- a/src/Checkbox/Checkbox-styled.js
+++ b/src/Checkbox/Checkbox-styled.js
@@ -31,6 +31,7 @@ const StyledDisplayCheckbox = styled.div`
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  flex-shrink: 0;
   background: ${props => props.theme.palette.white};
   border: 1px solid ${props => props.theme.palette.gray};
   color: ${props => props.theme.palette.white};


### PR DESCRIPTION
## Description
Fix an issue where `Checkbox` width was not being set when unchecked and in a container that is smaller than the width of the checkbox + label.

## Screenshots (if appropriate):
![MicrosoftTeams-image](https://user-images.githubusercontent.com/5149922/76474524-39eaa500-63b9-11ea-90e4-54b8356eb945.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
