### PR TITLE
Fix Search clear button overlap when RTL

### DIFF
--- a/src/Search/Search-styled.js
+++ b/src/Search/Search-styled.js
@@ -155,7 +155,7 @@ const StyledSearch = styled(CalciteInput)`
       padding-left: ${props => unitCalc(props.theme.baseline, 1.2, '*')};
 
       html[dir='rtl'] & {
-        padding-left: initial;
+        padding-left: ${props => props.theme.baseline};
         padding-right: ${props => unitCalc(props.theme.baseline, 1.2, '*')};
       }
     `};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The styled-components styles used here seemed to assume that `padding-left: initial` would still receive the RTL rules specified above, which is not the case. Duplicating the `${props => props.theme.baseline}` amount, as used above, seems to be necessary here.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#356 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
