### PR TITLE
Small stepper

### DIFF
--- a/src/Stepper/Stepper-styled.js
+++ b/src/Stepper/Stepper-styled.js
@@ -114,7 +114,6 @@ StyledStepTextContainer.defaultProps = { theme };
 
 const StyledStepTitle = styled(CalciteH6)`
   margin: 0;
-  margin-bottom: ${props => unitCalc(props.theme.baseline, 5, '/')};
   line-height: 32px;
   position: relative;
   color: ${props => props.theme.palette.darkGray};
@@ -130,7 +129,6 @@ const StyledStepTitle = styled(CalciteH6)`
     css`
       ${fontSize(-2)};
       line-height: 28px;
-      margin-bottom: 0;
     `};
 
   ${props =>
@@ -187,6 +185,14 @@ const StyledStepTitle = styled(CalciteH6)`
   ${props =>
     props.vertical &&
     css`
+      margin-bottom: ${props => unitCalc(props.theme.baseline, 5, '/')};
+
+      ${props =>
+        props.small &&
+        css`
+          margin-bottom: 0;
+        `};
+
       &::after {
         content: none;
       }
@@ -228,6 +234,9 @@ StyledStepDescription.defaultProps = { theme };
 
 const StyledStepIcon = styled.div`
   position: relative;
+  display: flex;
+  align-items: center;
+  height: 32px;
 
   ${props =>
     props.vertical &&
@@ -276,6 +285,12 @@ const StyledStepIcon = styled.div`
       *:last-of-type > &::after {
         content: none;
       }
+    `};
+
+  ${props =>
+    props.small &&
+    css`
+      height: 28px;
     `};
 `;
 StyledStepIcon.defaultProps = { theme };

--- a/src/Stepper/Stepper-styled.js
+++ b/src/Stepper/Stepper-styled.js
@@ -114,6 +114,7 @@ StyledStepTextContainer.defaultProps = { theme };
 
 const StyledStepTitle = styled(CalciteH6)`
   margin: 0;
+  margin-bottom: ${props => unitCalc(props.theme.baseline, 5, '/')};
   line-height: 32px;
   position: relative;
   color: ${props => props.theme.palette.darkGray};
@@ -129,6 +130,7 @@ const StyledStepTitle = styled(CalciteH6)`
     css`
       ${fontSize(-2)};
       line-height: 28px;
+      margin-bottom: 0;
     `};
 
   ${props =>

--- a/src/Stepper/doc/Stepper.mdx
+++ b/src/Stepper/doc/Stepper.mdx
@@ -158,12 +158,15 @@ import Stepper, {
     <Stepper vertical small currentStep={2}>
       <Step>
         <StepTitle>Complete Step</StepTitle>
+        <StepDescription>This is the first step in a series</StepDescription>
       </Step>
       <Step error>
         <StepTitle>Error Step</StepTitle>
+        <StepDescription>This is the second step in a series</StepDescription>
       </Step>
       <Step>
         <StepTitle>Pending Step</StepTitle>
+        <StepDescription>This is the third step in a series</StepDescription>
       </Step>
     </Stepper>
   </GuideExample>


### PR DESCRIPTION
## Description
Update styles for small stepper so that the description text fits better.

## Motivation and Context
Up until now we just assumed a small stepper wouldn't include the description text, we now support displaying it in a smaller format.

## Screenshots (if appropriate):
<img width="434" alt="Screen Shot 2020-03-25 at 11 42 33 AM" src="https://user-images.githubusercontent.com/5149922/77568150-d5861600-6e8d-11ea-9758-699e181cc25a.png">

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
