### PR TITLE
Extra clear button in Search on Edge

### DIFF
--- a/src/Search/Search-styled.js
+++ b/src/Search/Search-styled.js
@@ -144,6 +144,10 @@ const StyledSearch = styled(CalciteInput)`
   padding-right: ${props => props.theme.baseline};
   background: transparent;
 
+  &::-ms-clear {
+    display: none;
+  }
+
   html[dir='rtl'] & {
     padding-right: ${props => unitCalc(props.theme.baseline, 5, '/')};
     padding-left: ${props => props.theme.baseline};

--- a/src/Search/Search.js
+++ b/src/Search/Search.js
@@ -375,6 +375,7 @@ class Search extends Component {
                             ref,
                             selectableListFilter: listContext.selectable,
                             searchIcon,
+                            type: 'text',
                             ...other
                           })}
                         />


### PR DESCRIPTION
## Description
- Hide the clear button in the `Search` component on Edge

## Related Issue
#362 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
