### PR TITLE
Update Tabs translucent style

### DIFF
--- a/src/Tabs/Tab-styled.js
+++ b/src/Tabs/Tab-styled.js
@@ -159,7 +159,7 @@ const StyledTabTitle = styled(CalciteA)`
           border-bottom: 3px solid transparent;
           color: ${props.theme.palette.darkerGray};
           margin-right: ${unitCalc(props.theme.baseline, 2, '/')};
-          transition: none;
+          transition: transition: all 0.15s ease-in-out 0s;
           padding: ${props => unitCalc(props.theme.baseline, 2, '/')} 0;
 
           html[dir='rtl'] & {

--- a/src/Tabs/Tab-styled.js
+++ b/src/Tabs/Tab-styled.js
@@ -316,6 +316,8 @@ const StyledTabSection = styled.article`
     props.translucent &&
     css`
       background-color: ${props => props.theme.palette.opaqueWhite};
+      padding-left: 0;
+      padding-right: 0;
     `};
 
   ${props =>

--- a/src/Tabs/Tab-styled.js
+++ b/src/Tabs/Tab-styled.js
@@ -159,7 +159,7 @@ const StyledTabTitle = styled(CalciteA)`
           border-bottom: 3px solid transparent;
           color: ${props.theme.palette.darkerGray};
           margin-right: ${unitCalc(props.theme.baseline, 2, '/')};
-          transition: transition: all 0.15s ease-in-out 0s;
+          transition: all 0.15s ease-in-out 0s;
           padding: ${props => unitCalc(props.theme.baseline, 2, '/')} 0;
 
           html[dir='rtl'] & {

--- a/src/Tabs/Tab-styled.js
+++ b/src/Tabs/Tab-styled.js
@@ -153,18 +153,18 @@ const StyledTabTitle = styled(CalciteA)`
       ${props =>
         props.translucent &&
         css`
-          background-color: ${props => props.theme.palette.transparentWhite};
+          background-color: transparent;
           background-image: none;
           border: none;
-          border-top: 2px solid ${props => props.theme.palette.transparentWhite};
-          color: ${props => props.theme.palette.offBlack};
-          margin-right: 2px;
-          margin-bottom: 3px;
+          border-bottom: 3px solid transparent;
+          color: ${props.theme.palette.darkerGray};
+          margin-right: ${unitCalc(props.theme.baseline, 2, '/')};
           transition: none;
+          padding: ${props => unitCalc(props.theme.baseline, 2, '/')} 0;
 
           html[dir='rtl'] & {
             margin-right: 0;
-            margin-left: 2px;
+            margin-left: ${unitCalc(props.theme.baseline, 2, '/')};
           }
 
           &:first-child,
@@ -175,20 +175,24 @@ const StyledTabTitle = styled(CalciteA)`
 
           &:hover,
           &:focus {
-            background-color: ${props => props.theme.palette.opaqueWhite};
-            border-top-color: ${props => props.theme.palette.blue};
+            background-color: transparent;
+            border-bottom-color: ${props.theme.palette.lighterGray};
             background-image: none;
+            color: ${props.theme.palette.offBlack};
           }
 
           ${props =>
             props.active &&
             css`
-              background-image: none;
-              background-color: ${props => props.theme.palette.opaqueWhite};
-              border-top-color: ${props => props.theme.palette.blue};
-              border-bottom: 2px solid
-                ${props => props.theme.palette.opaqueWhite};
-              margin-bottom: 0;
+              &,
+              &:hover,
+              &:focus {
+                background-image: none;
+                background-color: transparent;
+                border-bottom-color: ${props.theme.palette.blue};
+                color: ${props.theme.palette.offBlack};
+                font-weight: bold;
+              }
             `};
         `};
 
@@ -263,15 +267,16 @@ const StyledTabContents = styled.div`
     `};
 
   ${props =>
-    props.translucent &&
+    props.dark &&
     css`
       border: none;
     `};
 
   ${props =>
-    props.dark &&
+    props.translucent &&
     css`
       border: none;
+      border-top: 1px solid ${props.theme.palette.lighterGray};
     `};
 `;
 StyledTabContents.defaultProps = { theme };

--- a/src/Tabs/doc/Tabs.mdx
+++ b/src/Tabs/doc/Tabs.mdx
@@ -31,9 +31,9 @@ import Tabs, {
 <Playground>
   <Tabs activeTabIndex={0}>
     <TabNav>
-      <TabTitle>Tab 1</TabTitle>
-      <TabTitle>Tab 2</TabTitle>
-      <TabTitle>Tab 3</TabTitle>
+      <TabTitle>Tab 1 Title</TabTitle>
+      <TabTitle>Tab 2 Title</TabTitle>
+      <TabTitle>Tab 3 Title</TabTitle>
     </TabNav>
     <TabContents>
       <TabSection>Tab 1 content</TabSection>
@@ -49,9 +49,9 @@ import Tabs, {
   <GuideExample label="gray">
     <Tabs gray activeTabIndex={0}>
       <TabNav>
-        <TabTitle>Tab 1</TabTitle>
-        <TabTitle>Tab 2</TabTitle>
-        <TabTitle>Tab 3</TabTitle>
+        <TabTitle>Tab 1 Title</TabTitle>
+        <TabTitle>Tab 2 Title</TabTitle>
+        <TabTitle>Tab 3 Title</TabTitle>
       </TabNav>
       <TabContents>
         <TabSection>Tab 1 content</TabSection>
@@ -63,9 +63,9 @@ import Tabs, {
   <GuideExample label="transparent">
     <Tabs transparent activeTabIndex={0}>
       <TabNav>
-        <TabTitle>Tab 1</TabTitle>
-        <TabTitle>Tab 2</TabTitle>
-        <TabTitle>Tab 3</TabTitle>
+        <TabTitle>Tab 1 Title</TabTitle>
+        <TabTitle>Tab 2 Title</TabTitle>
+        <TabTitle>Tab 3 Title</TabTitle>
       </TabNav>
       <TabContents>
         <TabSection>Tab 1 content</TabSection>
@@ -77,9 +77,9 @@ import Tabs, {
   <GuideExample label="translucent">
     <Tabs translucent activeTabIndex={0}>
       <TabNav>
-        <TabTitle>Tab 1</TabTitle>
-        <TabTitle>Tab 2</TabTitle>
-        <TabTitle>Tab 3</TabTitle>
+        <TabTitle>Tab 1 Title</TabTitle>
+        <TabTitle>Tab 2 Title</TabTitle>
+        <TabTitle>Tab 3 Title</TabTitle>
       </TabNav>
       <TabContents>
         <TabSection>Tab 1 content</TabSection>
@@ -91,9 +91,9 @@ import Tabs, {
   <GuideExample label="dark">
     <Tabs dark activeTabIndex={0}>
       <TabNav>
-        <TabTitle>Tab 1</TabTitle>
-        <TabTitle>Tab 2</TabTitle>
-        <TabTitle>Tab 3</TabTitle>
+        <TabTitle>Tab 1 Title</TabTitle>
+        <TabTitle>Tab 2 Title</TabTitle>
+        <TabTitle>Tab 3 Title</TabTitle>
       </TabNav>
       <TabContents>
         <TabSection>Tab 1 content</TabSection>
@@ -129,9 +129,9 @@ import Tabs, {
               activeTabIndex={this.state.activeTabIndex}
             >
               <TabNav>
-                <TabTitle>Tab 1</TabTitle>
-                <TabTitle>Tab 2</TabTitle>
-                <TabTitle>Tab 3</TabTitle>
+                <TabTitle>Tab 1 Title</TabTitle>
+                <TabTitle>Tab 2 Title</TabTitle>
+                <TabTitle>Tab 3 Title</TabTitle>
               </TabNav>
               <TabContents>
                 <TabSection>Tab 1 content</TabSection>


### PR DESCRIPTION
## Description
Update the styles for the `translucent` variant of `Tabs`

## Related Issue
#366 will not directly be resolved by this as the standard style is unchanged; however, we encourage users with accessibility concerns to use this updated `translucent` style. This will likely become the default style at a 1.0.0 release.

## Motivation and Context
This will bring calcite react more closely in line with calcite components implementation of `Tabs`. 

## Screenshots (if appropriate):
Now:
<img width="622" alt="Screen Shot 2020-04-03 at 2 35 52 PM" src="https://user-images.githubusercontent.com/5149922/78402847-8c824000-75b8-11ea-9c2a-1eca8afd2551.png">

Before:
<img width="589" alt="Screen Shot 2020-04-03 at 4 22 33 PM" src="https://user-images.githubusercontent.com/5149922/78409663-7c259180-75c7-11ea-9adf-45fd9112e350.png">

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
