### PR TITLE
Reset button margin for safari

### DIFF
--- a/src/Button/Button-styled.js
+++ b/src/Button/Button-styled.js
@@ -36,6 +36,7 @@ const StyledButton = styled.button`
   justify-content: center;
   padding: ${props => unitCalc(props.theme.baseline, 5, '/')} 0.9rem;
   width: auto;
+  margin: 0;
   color: ${props => props.theme.palette.white};
   border: 1px solid ${props => props.theme.palette.blue};
   border-radius: ${props => props.theme.borderRadius};


### PR DESCRIPTION
## Description
Fixes `Button` margin on Safari to match all other browsers.

## Related Issue
https://github.com/EsriPS/Indoors-WebApp/issues/2196

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/5149922/79495029-37472500-7fe1-11ea-8e2c-ba9b7c7463d9.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
