### PR TITLE
Align ArcGISAccount styles for long user names

### DIFF
--- a/src/ArcgisAccount/ArcgisAccount-styled.js
+++ b/src/ArcgisAccount/ArcgisAccount-styled.js
@@ -31,6 +31,7 @@ const StyledArcgisAccountControl = styled.div`
   color: ${props => props.theme.palette.darkestGray};
   cursor: pointer;
   height: 62px;
+  max-width: 260px;
   padding: ${props => unitCalc(props.theme.baseline, 2, '/')}
     ${props => props.theme.baseline}
     ${props => unitCalc(props.theme.baseline, 2, '/')}
@@ -90,6 +91,10 @@ const StyledArcgisAccountControlFriendlyName = styled.span`
   font-weight: 600;
   ${fontSize(-1)};
   line-height: 20px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  max-width: 170px;
 `;
 StyledArcgisAccountControlFriendlyName.defaultProps = { theme };
 const StyledArcgisAccountControlUsername = styled.span`
@@ -123,6 +128,8 @@ StyledArcgisAccountContentInfo.defaultProps = { theme };
 const StyledArcgisAccountContentName = styled.span`
   ${fontSize(1)};
   font-weight: 600;
+  word-break: break-word;
+  text-align: center;
   display: inline-block;
   margin-bottom: ${props => unitCalc(props.theme.baseline, 2, '/')};
 `;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Align behavior for long user names with agol.
1. Set `max-width` for `ArcgisAccountControl`
2. Use `text-overflow: ellipsis` for full name in `ArcgisAccountControl`.
3. `break-word` in menu

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in major browser with long and short names as well as different width's.

## Screenshots:
Before:
![Screen Shot 2020-04-27 at 16 25 29](https://user-images.githubusercontent.com/5748802/80384538-4bbed380-88a5-11ea-8211-8c98ef70c3b2.png)

After:
![Screen Shot 2020-04-27 at 16 24 06](https://user-images.githubusercontent.com/5748802/80384556-524d4b00-88a5-11ea-8b0d-d209086e68ab.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
