### PR TITLE
Fix horizontal scrollbar in Select menu on firefox

### DIFF
--- a/src/Select/Select-styled.js
+++ b/src/Select/Select-styled.js
@@ -21,6 +21,7 @@ import { CalciteTheme as theme } from '../CalciteThemeProvider';
 
 // Calcite components
 import Menu from '../Menu';
+import { StyledMenuItem } from '../Menu/Menu-styled';
 
 // Icons
 
@@ -72,6 +73,11 @@ const StyledSelectMenu = styled(Menu)`
     css`
       min-width: 100%;
     `};
+
+  ${StyledMenuItem} {
+    -moz-padding-inline-end: ${props => props.theme.baseline};
+    -moz-padding-end: ${props => props.theme.baseline};
+  }
 
   /* Handles iframe styling from react-resize-aware */
   iframe {


### PR DESCRIPTION
## Description
Adds style for Firefox to add extra padding to `Select` menu.

## Related Issue
#376 

## Motivation and Context
Firefox doesn't calculate intrinsic width properly when a vertical scrollbar is added. https://bugzilla.mozilla.org/show_bug.cgi?id=764076

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
