### PR TITLE
Remove section about filled icons from doc page

### DIFF
--- a/docz/Calcite_Icons.mdx
+++ b/docz/Calcite_Icons.mdx
@@ -53,16 +53,6 @@ automatically select an icon for you based on the size you specify.
   <LayerBasemapIcon size={64} />
 </Playground>
 
-### Outline vs. Filled
-
-Icons allow you to specify whether they should use the outline style or the
-`filled` style. Outline is the default for all Calcite UI Icons.
-
-<Playground>
-  <MagnifyingGlassIcon />
-  <MagnifyingGlassIcon filled />
-</Playground>
-
 ### Color
 
 All icons accept a color prop, which will be applied to the fill attribute on
@@ -72,8 +62,8 @@ we will set it to "currentColor".
 
 <Playground>
   <GlobeIcon color="red" />
-  <GlobeIcon filled color="#1d5d8c" />
-  <GlobeIcon filled color="rgba(155, 30, 95, 0.5)" />
+  <GlobeIcon color="#1d5d8c" />
+  <GlobeIcon color="rgba(155, 30, 95, 0.5)" />
 </Playground>
 
 ### Gotchas

--- a/docz/IconDemo.js
+++ b/docz/IconDemo.js
@@ -14,8 +14,7 @@ import ThreeDGlassesIcon from 'calcite-ui-icons-react/ThreeDGlassesIcon';
 export default class IconDemo extends Component {
   state = {
     size: 200,
-    color: 'tomato',
-    filled: false
+    color: 'tomato'
   };
 
   render() {
@@ -51,40 +50,27 @@ export default class IconDemo extends Component {
               }
             />
           </FormControl>
-
-          <FormControl>
-            <FormControlLabel>Filled:</FormControlLabel>
-            <Switch
-              checked={this.state.filled}
-              onChange={e => this.setState({ filled: e.target.checked })}
-            />
-          </FormControl>
         </Form>
         <div style={{ textAlign: 'center', height: '220px', overflow: 'auto' }}>
           <BananaIcon
             size={this.state.size}
             color={this.state.color}
-            filled={this.state.filled}
           />
           <BasemapIcon
             size={this.state.size}
             color={this.state.color}
-            filled={this.state.filled}
           />
           <RunningIcon
             size={this.state.size}
             color={this.state.color}
-            filled={this.state.filled}
           />
           <ThreeDGlassesIcon
             size={this.state.size}
             color={this.state.color}
-            filled={this.state.filled}
           />
           <BatteryChargingIcon
             size={this.state.size}
             color={this.state.color}
-            filled={this.state.filled}
           />
         </div>
       </Fragment>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Removes references to the deprecated `filled` property on calcite-ui-icons-react icons in the Calcite Icons doc page.

## Motivation and Context
`filled` was recently deprecated by calcite-ui-icons-react, and should no longer be mentioned in the calcite-react docs.

## How Has This Been Tested?
The Netlify deploy preview associated with this PR should prove sufficient.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
