### PR TITLE
Refactor unitCalc without using eval to support SSR/SSG

### DIFF
--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -37,6 +37,8 @@ const unitCalc = (left, right, operator) => {
       return left / right + unit;
     case '%':
       return (left % right) + unit;
+    default:
+      return undefined;
   }
 };
 

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -38,7 +38,8 @@ const unitCalc = (left, right, operator) => {
     case '%':
       return (left % right) + unit;
     default:
-      return undefined;
+      console.warn('unitCalc only supports the following operators: +, -, *, /, %');
+      return left;
   }
 };
 

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -13,27 +13,31 @@ import { useEffect, useState } from 'react';
 import { transparentize } from 'polished';
 import { CalciteTheme } from '../CalciteThemeProvider';
 
-const unitCalc = (operand1, operand2, operator) => {
-  let operand1Value = operand1;
-  let operand1Unit;
-  if (typeof operand1 === 'string') {
-    operand1Value = parseFloat(operand1);
-    operand1Unit = operand1.replace(operand1Value, '');
+const unitCalc = (left, right, operator) => {
+  let leftUnit, rightUnit;
+  if (typeof left === 'string') {
+    leftUnit = left.replace(parseFloat(left), '');
+    left = parseFloat(left);
+  }
+  if (typeof right === 'string') {
+    rightUnit = right.replace(parseFloat(right), '');
+    right = parseFloat(right);
   }
 
-  let operand2Value = operand2;
-  let operand2Unit;
-  if (typeof operand2 === 'string') {
-    operand2Value = parseFloat(operand2);
-    operand2Unit = operand2.replace(operand2Value, '');
+  const unit = leftUnit || rightUnit;
+
+  switch (operator) {
+    case '+':
+      return left + right + unit;
+    case '-':
+      return left - right + unit;
+    case '*':
+      return left * right + unit;
+    case '/':
+      return left / right + unit;
+    case '%':
+      return (left % right) + unit;
   }
-
-  let value =
-    typeof window !== 'undefined' &&
-    window.eval(operand1Value + operator + operand2Value); // eslint-disable-line no-eval
-  value = value + (operand1Unit || operand2Unit);
-
-  return value;
 };
 
 // const unitCompare = (compare1, compare2, operator) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR refactors `unitCalc` so that it doesn't need to rely on `window` or `eval` to function properly. This makes it isomorphic and conducive to SSR/SSG.

**kudos to @hogpilot for recommending the logic update here 🙏🏼 🎉** 

## Related Issue
#396

## Motivation and Context
Calcite React mostly works with SSR/SSG frameworks like Next.js or Gatsby, but when `unitCalc` gets executed server-side, it returns incorrect values (see #396 for more details).

## How Has This Been Tested?
The following sandbox is forked from the repro sandbox for #396 but is using the updated `unitCalc` function.

https://codesandbox.io/s/silent-grass-mug16?file=/pages/index.js

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
