### PR TITLE
Set virtualized List direction off document dir

### DIFF
--- a/src/MultiSelect/MultiSelect.js
+++ b/src/MultiSelect/MultiSelect.js
@@ -199,6 +199,9 @@ const MultiSelect = ({
               rowRenderStyle
             });
           }}
+          style={{
+            direction: document.documentElement.dir || 'ltr'
+          }}
         />
       );
     }

--- a/src/MultiSelect/MultiSelect.js
+++ b/src/MultiSelect/MultiSelect.js
@@ -200,7 +200,7 @@ const MultiSelect = ({
             });
           }}
           style={{
-            direction: document.documentElement.dir || 'ltr'
+            direction: (document && document.documentElement.dir) || 'ltr'
           }}
         />
       );

--- a/src/Search/Search.js
+++ b/src/Search/Search.js
@@ -259,6 +259,9 @@ class Search extends Component {
               rowRenderStyle
             });
           }}
+          style={{
+            direction: document.documentElement.dir || 'ltr'
+          }}
         />
       );
     }

--- a/src/Search/Search.js
+++ b/src/Search/Search.js
@@ -260,7 +260,7 @@ class Search extends Component {
             });
           }}
           style={{
-            direction: document.documentElement.dir || 'ltr'
+            direction: (document && document.documentElement.dir) || 'ltr'
           }}
         />
       );

--- a/src/Select/Select.js
+++ b/src/Select/Select.js
@@ -227,7 +227,7 @@ class Select extends Component {
             });
           }}
           style={{
-            direction: document.documentElement.dir || 'ltr'
+            direction: (document && document.documentElement.dir) || 'ltr'
           }}
         />
       );

--- a/src/Select/Select.js
+++ b/src/Select/Select.js
@@ -226,6 +226,9 @@ class Select extends Component {
               rowRenderStyle
             });
           }}
+          style={{
+            direction: document.documentElement.dir || 'ltr'
+          }}
         />
       );
     }

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -254,7 +254,7 @@ const getAccessibleOnClickHandlers = onClick => {
 };
 
 const rtlPlacement = placement => {
-  if (placement && document.documentElement.dir === 'rtl') {
+  if (placement && document && document.documentElement.dir === 'rtl') {
     const hash = {
       end: 'start',
       start: 'end',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Manually sets CSS direction of the root element of `react-virtualized`'s `List` as per their recommendation
https://github.com/bvaughn/react-virtualized/issues/457
@jpeterson do you think this will have SSR issues?

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #405 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Altering `dir` attribute on `html` element in dev server docs

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/5069711/92183371-071ee800-ee03-11ea-8c71-3e3e9766352a.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
