### PR TITLE
Fix #407 by setting white-space to normal for account menu buttons

### DIFF
--- a/src/ArcgisAccount/ArcgisAccount-styled.js
+++ b/src/ArcgisAccount/ArcgisAccount-styled.js
@@ -228,12 +228,14 @@ StyledArcgisAccountMenuItem.defaultProps = { theme };
 
 const StyledSwitchAccountButton = styled(Button)`
   flex: 1 0 50px;
+  white-space: normal;
   border-radius: 0 0 0 ${props => props.theme.borderRadius};
 `;
 StyledSwitchAccountButton.defaultProps = { theme };
 
 const StyledSignOutButton = styled(Button)`
   flex: 1 0 50px;
+  white-space: normal;
   margin-left: 0;
   border-radius: 0 0 ${props => props.theme.borderRadius} 0;
 `;


### PR DESCRIPTION
## Description
Set `white-space: normal` for 'Switch Account' and 'Sign out' buttons to make sure that long labels will wrap.

## Related Issue
#407 

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate):
Before:
<img width="478" alt="Screen Shot 2020-09-04 at 09 17 08" src="https://user-images.githubusercontent.com/5748802/92212139-cc17c580-ee91-11ea-8066-fad995800a03.png">

After:
<img width="478" alt="Screen Shot 2020-09-04 at 09 19 39" src="https://user-images.githubusercontent.com/5748802/92212147-d043e300-ee91-11ea-9751-8003dbe5b355.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
