### PR TITLE
Bug bread crumb styles

### DIFF
--- a/src/Breadcrumbs/Breadcrumbs-styled.js
+++ b/src/Breadcrumbs/Breadcrumbs-styled.js
@@ -88,7 +88,6 @@ const StyledSpanCrumb = styled.span`
     props.white &&
     css`
       color: ${props.theme.palette.white};
-      ${linkColor(props.theme.palette.white, props.theme.palette.lightestGray)};
 
       &::before {
         color: ${props.theme.palette.white};

--- a/src/Breadcrumbs/Crumb.js
+++ b/src/Breadcrumbs/Crumb.js
@@ -39,7 +39,9 @@ Crumb.propTypes = {
   /** href html prop */
   href: PropTypes.string,
   /** The character used as a divider between Crumbs; by default it will inherit the parent Breadcrumbs dividerCharacter */
-  dividerCharacter: PropTypes.node
+  dividerCharacter: PropTypes.node,
+  /** Use hasLink as a way to maintain the calcite link styles when no href is given (useful when using a Crumb with an outside routing library). */
+  hasLink: PropTypes.bool
 };
 
 Crumb.defaultProps = {};


### PR DESCRIPTION
- Removed hover effect on SpanCrumb because it has no associated action
- Exposed hasLink prop to optionally still render a link instead of a span when no href is present (like when using a crumb as a ReactRouter Link)