### PR TITLE
Use `flex: 0 0 auto` for Modal header

### DIFF
--- a/src/Modal/Modal-styled.js
+++ b/src/Modal/Modal-styled.js
@@ -93,7 +93,7 @@ const StyledModalHeader = styled.div`
   max-width: 100%;
   min-width: 0;
   z-index: 2;
-  flex: 0 1 0%;
+  flex: 0 0 auto;
   border-bottom: 1px solid ${props => props.theme.palette.lightestGray};
 `;
 StyledModalHeader.defaultProps = { theme };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Use `flex: 0 0 auto` instead of `flex: 0 1 0%` for sizing the Modal header. Mirrors current CSS in calcite-components.

## Motivation and Context
Better compatibility in WebKit. Header would get collapsed to 0px height due to having no flex-basis.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
