### PR TITLE
add option for switch to take custom colors

### DIFF
--- a/src/Switch/Switch-styled.js
+++ b/src/Switch/Switch-styled.js
@@ -26,7 +26,7 @@ import { StyledFormControlLabel } from '../Form/Form-styled';
 // Icons
 
 // Third party libraries
-import { transparentize } from 'polished';
+import { transparentize, lighten, darken } from 'polished';
 
 const switchProps = {
   switchWidth: '36px',
@@ -253,6 +253,49 @@ const StyledSwitchTrack = styled.span`
 
         &:after {
           border-color: ${switchProps.handleDestructiveCheckedBorderColor};
+        }
+      }
+    `};
+
+  ${props =>
+    props.color &&
+    css`
+      input:hover + &:after {
+        border-color: ${lighten(0.2, props.color)};
+      }
+
+      input:active + &:after {
+        border-color: ${lighten(0.2, props.color)};
+      }
+
+      input:checked:active + & {
+        box-shadow: 0 0 4px 2px
+          ${transparentize(0.6, lighten(0.2, props.color))};
+
+        &:after {
+          border-color: ${lighten(0.2, props.color)};
+        }
+      }
+
+      input:checked + & {
+        background-color: ${lighten(0.2, props.color)};
+        border-color: ${props.color};
+
+        &:after {
+          border-color: ${lighten(0.2, props.color)};
+        }
+      }
+
+      input:focus + &:after {
+        border-color: ${lighten(0.2, props.color)};
+      }
+
+      input:checked:focus + & {
+        box-shadow: 0 0 4px 2px
+          ${transparentize(0.6, lighten(0.2, props.color))};
+
+        &:after {
+          border-color: ${lighten(0.2, props.color)};
         }
       }
     `};

--- a/src/Switch/Switch.js
+++ b/src/Switch/Switch.js
@@ -116,7 +116,7 @@ Switch.propTypes = {
   onChange: PropTypes.func,
   /** Should use a red highlight color. */
   destructive: PropTypes.bool,
-  /** Color  */
+  /** The color of the Switch. 'green' | 'rgb(0, 255, 255)' | '#fefefe'  */
   color: PropTypes.string,
   /** Position of the label text in relation to the input. */
   labelPosition: PropTypes.oneOf(['before', 'after']),

--- a/src/Switch/Switch.js
+++ b/src/Switch/Switch.js
@@ -24,6 +24,7 @@ const Switch = ({
   labelPosition,
   fullWidth,
   destructive,
+  color,
   checked,
   field,
   form,
@@ -98,7 +99,7 @@ const Switch = ({
         {...other}
         type="checkbox"
       />
-      <StyledSwitchTrack destructive={destructive} />
+      <StyledSwitchTrack destructive={destructive} color={color} />
       {labelPosition === 'after' ? getSwitchLabel(children) : null}
     </StyledSwitch>
   );
@@ -115,6 +116,8 @@ Switch.propTypes = {
   onChange: PropTypes.func,
   /** Should use a red highlight color. */
   destructive: PropTypes.bool,
+  /** Color  */
+  color: PropTypes.string,
   /** Position of the label text in relation to the input. */
   labelPosition: PropTypes.oneOf(['before', 'after']),
   /** Switch and label will take up the full width of the container */

--- a/src/Switch/doc/Switch.mdx
+++ b/src/Switch/doc/Switch.mdx
@@ -18,7 +18,7 @@ A skin on a checkbox.
 #### Import Syntax
 
 ```js
-import Switch from 'calcite-react/Switch'
+import Switch from 'calcite-react/Switch';
 ```
 
 ## Basic Usage
@@ -40,6 +40,31 @@ import Switch from 'calcite-react/Switch'
   </GuideExample>
 </Playground>
 
+## Alternate Colors
+
+<Playground>
+  <GuideExample label="color">
+    <Switch checked color="green">
+      green
+    </Switch>
+    <Switch checked color="#64DAA1">
+      #64DAA1
+    </Switch>
+    <Switch checked color="#060080">
+      #060080
+    </Switch>
+    <Switch checked color="rgb(127,255,0)">
+      rgb(127,255,0)
+    </Switch>
+    <Switch checked color="rgb(32,178,170)">
+      rgb(32,178,170)
+    </Switch>
+    <Switch checked color="rgb(165,42,42)">
+      rgb(165,42,42)
+    </Switch>
+  </GuideExample>
+</Playground>
+
 ## fullWidth
 
 <Playground>
@@ -47,7 +72,9 @@ import Switch from 'calcite-react/Switch'
     <Switch fullWidth>Enable Two-Factor Authentication</Switch>
   </GuideExample>
   <GuideExample>
-    <Switch fullWidth labelPosition="before">Enable Two-Factor Authentication</Switch>
+    <Switch fullWidth labelPosition="before">
+      Enable Two-Factor Authentication
+    </Switch>
   </GuideExample>
 </Playground>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
let the `<Switch>` take a `color` option to change the bg & border colors

## Related Issue
n/a

## Motivation and Context
I want moar colors!

## How Has This Been Tested?
just cloned the repo locally, built the docs, and added a sample section in the docs

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/5233042/97518462-349c9380-1965-11eb-8c9d-de3ec7357905.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (i think??)
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
