### PR TITLE
Bugfix: Resolve state issues in useAccountManager addAccount/switchActiveAccount 

### DIFF
--- a/src/AccountTile/doc/AccountTile.mdx
+++ b/src/AccountTile/doc/AccountTile.mdx
@@ -193,6 +193,8 @@ import AccountTile from 'calcite-react/AccountTile';
       const createActions = (key, isAuthenticated) => {
         let actions = [{
             label: 'Remove account', onClick: () => removeAccount(accounts[key])
+        }, {
+            label: 'Set active', onClick: () => switchActiveAccount(accounts[key])
         }];
         if (isAuthenticated) {
           actions.unshift({

--- a/src/ArcgisAccount/accountManagerStorageUtils.js
+++ b/src/ArcgisAccount/accountManagerStorageUtils.js
@@ -17,10 +17,11 @@ export const addAccountStorage = (manager, account) => {
   const previous = getLocalSerialized(manager);
   const { accounts, active, status: setActive } = previous || {};
   const updateActive = setActive || !active ? account.key : active;
-  const order =
-    previous.order && !accounts[account.key]
-      ? [account.key, ...previous.order]
-      : [];
+  const order = previous.order
+    ? previous.order.find(id => id === account.key)
+      ? [...previous.order]
+      : [account.key, ...previous.order]
+    : [account.key];
   setLocal({
     state: {
       ...previous,
@@ -56,7 +57,8 @@ export const removeAccountStorage = (manager, { key }) => {
 
 export const switchActiveStorage = (manager, { key }) => {
   const previous = getLocalSerialized(manager);
-  const order = [key, ...previous.order.filter(item => item !== key)];
+  const orders = previous.order ? previous.order : [];
+  const order = [key, ...orders.filter(item => item !== key)];
   setLocal({
     state: {
       ...previous,

--- a/src/ArcgisAccount/useAccountManager.js
+++ b/src/ArcgisAccount/useAccountManager.js
@@ -298,7 +298,7 @@ const useAccountManager = (options, name = 'arcgis-account-manager') => {
       console.warn(invalid);
       return false;
     },
-    [accountManagerState, accountManagerState.accounts]
+    [accountManagerState]
   );
 
   return {

--- a/src/ArcgisAccount/useAccountManager.js
+++ b/src/ArcgisAccount/useAccountManager.js
@@ -209,7 +209,7 @@ const useAccountManager = (options, name = 'arcgis-account-manager') => {
         setAccountManagerState(accountManager);
       }
     },
-    [manager]
+    [accountManagerState, manager]
   );
 
   /** Check token status */
@@ -290,9 +290,15 @@ const useAccountManager = (options, name = 'arcgis-account-manager') => {
           : false;
         return valid;
       }
+      const invalid = {
+        warning: 'Invalid account',
+        account: account,
+        accountManagerState: accountManagerState
+      };
+      console.warn(invalid);
       return false;
     },
-    [accountManagerState]
+    [accountManagerState, accountManagerState.accounts]
   );
 
   return {


### PR DESCRIPTION
## Description

Resolve issue in addAccount and switchActiveAccount callback functions not handling state properly losing track of last added account when attempting to set an account to active state. 

## Related Issue
Issue #427 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Test in Docz environment in ArcgisAccount and AccountTile. 
Test by adding 2 or more accounts and switching active accounts. 
Monitor new warning messaging for valid account checks. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
