### PR TITLE
Update calcite-colors references to 6.0.0

### DIFF
--- a/docz/DoczCalciteTheme.js
+++ b/docz/DoczCalciteTheme.js
@@ -1,4 +1,4 @@
-import colors from '@esri/calcite-colors/colors.json';
+import { colors } from '@esri/calcite-colors';
 
 export default {
   // Removing logo for now as it overwrites the package name, removing any

--- a/package-lock.json
+++ b/package-lock.json
@@ -1332,9 +1332,9 @@
       "integrity": "sha512-hlmu7qGKteuF5NiVDX/oWuT6zJnq+P0ns6BkKM/s94MApZlS1FCFxAQS3wl/1MiUPtQykApE4prcyjlknuWglQ=="
     },
     "@esri/calcite-colors": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-colors/-/calcite-colors-1.7.1.tgz",
-      "integrity": "sha512-oZgYHKPLLfgo4teqDsnS9utYySL5ECYtqkGzXUMOu5J1vSS0Z/MlBEq6RMDm9+aHsDUnMZw6NuXDkaQzwfkzzQ=="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-colors/-/calcite-colors-6.0.0.tgz",
+      "integrity": "sha512-xsCRLwYHZ9wKFu4zhLTDXk28/wPiEVK4BDHwTr8o+AHCygoNfO2k9JjFP150avS53fldDOVqlEB+D0rr+CI5+w=="
     },
     "@hutson/parse-repository-url": {
       "version": "3.0.2",
@@ -2371,7 +2371,8 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
         "ms": {
@@ -6620,7 +6621,7 @@
       "dependencies": {
         "globby": {
           "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
           "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
           "dev": true,
           "requires": {
@@ -6633,7 +6634,7 @@
           "dependencies": {
             "pify": {
               "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+              "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
               "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
               "dev": true
             }
@@ -18927,7 +18928,7 @@
         },
         "camelcase-keys": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
           "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
           "dev": true,
           "requires": {
@@ -18937,7 +18938,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -18975,7 +18976,7 @@
         },
         "meow": {
           "version": "3.7.0",
-          "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+          "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
           "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
           "dev": true,
           "requires": {
@@ -21391,7 +21392,8 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
         "ms": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@esri/arcgis-rest-auth": "^2.14.1",
     "@esri/arcgis-rest-portal": "^2.14.1",
     "@esri/arcgis-rest-request": "^2.14.1",
-    "@esri/calcite-colors": "^1.7.1",
+    "@esri/calcite-colors": "6.0.0",
     "calcite-ui-icons-react": "^0.11.0",
     "downshift": "^3.4.1",
     "match-sorter": "^2.3.0",

--- a/src/Avatar/doc/Avatar.mdx
+++ b/src/Avatar/doc/Avatar.mdx
@@ -8,7 +8,7 @@ import GuideExample from '../../../docz/GuideExample';
 
 import Avatar from '../';
 
-import colors from '@esri/calcite-colors/colors.json';
+import { colors } from '@esri/calcite-colors';
 import CodyProfilePic from './codyProfile.jpeg';
 
 import DownloadToIcon from 'calcite-ui-icons-react/DownloadToIcon';
@@ -24,7 +24,7 @@ element that can be used in your UI. Avatars are commonly seen in user profiles.
 #### Import Syntax
 
 ```js
-import Avatar from 'calcite-react/Avatar'
+import Avatar from 'calcite-react/Avatar';
 ```
 
 ## Basic Usage

--- a/src/CalciteThemeProvider/CalciteTheme.js
+++ b/src/CalciteThemeProvider/CalciteTheme.js
@@ -9,7 +9,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.​
 
-import colors from '@esri/calcite-colors/colors.json';
+import { colors } from '@esri/calcite-colors';
 
 const CalciteTheme = {
   palette: {

--- a/src/Loader/doc/Loader.mdx
+++ b/src/Loader/doc/Loader.mdx
@@ -5,7 +5,7 @@ route: /loader
 
 import { Playground, PropsTable } from 'docz';
 import GuideExample from '../../../docz/GuideExample';
-import colors from '@esri/calcite-colors/colors.json';
+import { colors } from '@esri/calcite-colors';
 
 import Loader from '../';
 
@@ -17,7 +17,7 @@ rendered.
 #### Import Syntax
 
 ```js
-import Loader from 'calcite-react/Loader'
+import Loader from 'calcite-react/Loader';
 ```
 
 ## Basic Usage

--- a/src/Slider/Slider-styled.js
+++ b/src/Slider/Slider-styled.js
@@ -17,7 +17,7 @@ import { CalciteInput } from '../utils/commonElements';
 
 // Calcite theme and Esri colors
 import { CalciteTheme as theme } from '../CalciteThemeProvider';
-import colors from '@esri/calcite-colors/colors.json';
+import { colors } from '@esri/calcite-colors';
 
 // Calcite components
 

--- a/src/Switch/Switch-styled.js
+++ b/src/Switch/Switch-styled.js
@@ -18,7 +18,7 @@ import { baseRadioCheckbox } from '../utils/commonElements';
 
 // Calcite theme and Esri colors
 import { CalciteTheme as theme } from '../CalciteThemeProvider';
-import colors from '@esri/calcite-colors/colors.json';
+import { colors } from '@esri/calcite-colors';
 
 // Calcite components
 import { StyledFormControlLabel } from '../Form/Form-styled';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I updated the `@esri/calcite-colors` dependency to specifically the `6.0.0` release, and did a global search in the repo for instances of `calcite-colors`. The new import syntax is leveraging the `main` setting from calcite-colors' package.json and destructures the named `colors` export.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#444 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To help avoid package conflicts for projects using this package alongside other Calcite packages

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually comparing doc pages for components which reference calcite-colors such as Avatar, Toaster, and Slider

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
