### PR TITLE
Add deprecation notice to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# This project is deprecated and is not recommended for future development.
+
 # Documentation
 
 You can find the full docs for Calcite React here: https://calcite-react.netlify.com


### PR DESCRIPTION
## Description
Add a deprecation notice to our README

## Motivation and Context
The Calcite React repo is planned to be removed from the public Esri organization.
