### PR TITLE
Export `toast` object imported from `react-toastify` to give users access to increased `toast` methods.

### DIFF
--- a/src/Toaster/Toaster.js
+++ b/src/Toaster/Toaster.js
@@ -13,6 +13,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import { toast } from 'react-toastify';
+
 import 'react-toastify/dist/ReactToastify.css';
 
 import { StyledToaster, StyledCloseButton } from './Toaster-styled';

--- a/src/Toaster/Toaster.js
+++ b/src/Toaster/Toaster.js
@@ -95,6 +95,18 @@ const notify = (
       }
     );
   }
+
+  // Returning toastId will allow users to access id of specific toaster, which will let them manipulate that specific toaster only, if desired.
+  return toastId;
+};
+
+// If user passes specific toastId to closeDisplayedToast(), only close that toaster.  Otherwise, close all displayed toasts.
+const closeDisplayedToast = toasterId => {
+  if (toasterId) {
+    toast.dismiss(toasterId);
+  } else {
+    toast.dismiss();
+  }
 };
 
 class Toaster extends Component {
@@ -161,4 +173,4 @@ Toaster.defaultProps = {
 
 Toaster.displayName = 'Toaster';
 
-export { Toaster as default, notify };
+export { Toaster as default, notify, closeDisplayedToast };

--- a/src/Toaster/Toaster.js
+++ b/src/Toaster/Toaster.js
@@ -100,15 +100,6 @@ const notify = (
   return toastId;
 };
 
-// If user passes specific toastId to closeDisplayedToast(), only close that toaster.  Otherwise, close all displayed toasts.
-const closeDisplayedToast = toasterId => {
-  if (toasterId) {
-    toast.dismiss(toasterId);
-  } else {
-    toast.dismiss();
-  }
-};
-
 class Toaster extends Component {
   toastId = null;
 
@@ -173,4 +164,4 @@ Toaster.defaultProps = {
 
 Toaster.displayName = 'Toaster';
 
-export { Toaster as default, notify, closeDisplayedToast };
+export { Toaster as default, notify, toast };

--- a/src/Toaster/doc/Toaster.mdx
+++ b/src/Toaster/doc/Toaster.mdx
@@ -424,7 +424,7 @@ export default ToasterExampleComponent;
                   const mostRecentToaster = displayedToasterIds[displayedToasterIds.length - 1]
                     this.closeToaster(mostRecentToaster)
                   }
-                }>Close All Toasters</Button>
+                }>Close Only Most Recent Toaster</Button>
               </GuideExample>
             </Fragment>
           );

--- a/src/Toaster/doc/Toaster.mdx
+++ b/src/Toaster/doc/Toaster.mdx
@@ -6,10 +6,10 @@ route: /toaster
 import { Playground, PropsTable } from 'docz';
 import { Component, Fragment } from 'react';
 import GuideExample from '../../../docz/GuideExample';
-import { toast, Slide, Zoom, Flip } from 'react-toastify';
+import { Slide, Zoom, Flip } from 'react-toastify';
 
 import Button from '../../Button';
-import Toaster, { notify, ToastContainer, ToastTitle, ToastMessage } from '../';
+import Toaster, { toast, notify, ToastContainer, ToastTitle, ToastMessage } from '../';
 
 import ToasterExampleComponent from './ToasterExampleComponent';
 
@@ -19,7 +19,9 @@ import XIcon from 'calcite-ui-icons-react/XIcon';
 # Toaster
 
 Calcite React `Toaster` extends the react-toastify library with the `notify` method.
-Use `notify(content, options)` to display a toaster notification. View their
+Use `notify(content, options)` to display a toaster notification. 
+Use `toast` to access react-toastify object by same name.
+View their
 [documentation](https://github.com/fkhadra/react-toastify) to see available options.
 
 ### ⛔️ Use `notify` method ⛔️
@@ -354,6 +356,77 @@ export default ToasterExampleComponent;
         render() {
           return (
             <Button onClick={this.showToaster}>Show Toaster</Button>
+          );
+        }
+      }
+
+      return <ToasterStory />;
+    }}
+
+</Playground>
+
+## Dismiss toast (react-toastify `toast.dismiss()`)
+
+<Playground>
+  {() => {
+      class ToasterStory extends Component {
+        constructor(props) {
+          super(props);
+          this.displayedToasterIds = []
+          this.showCustomToaster = this.showCustomToaster.bind(this);
+        }
+
+        showCustomToaster({
+          content,
+          showIcon,
+          autoClose,
+          showProgress
+        }) {
+          const toastId = notify(content, {
+            showIcon,
+            autoClose,
+            showProgress
+          })
+
+          const displayedToasterIds = [...this.state.displayedToasterIds, toastId]
+
+          this.setState({ displayedToasterIds })
+        };
+
+        closeToaster(toasterId) {
+          if(!toasterId) {
+            toast.dismiss()
+            this.setState({ displayedToasterIds: [] })
+          } else {
+            toast.dismiss(toasterId)
+
+            const displayedToasterIds = this.state.displayedToasterIds.filter(id => id !== toasterId)
+            this.setState({ displayedToasterIds })
+          }
+        }
+
+        render() {
+          return (
+            <Fragment>
+              <GuideExample label='toaster open'>
+                <Button onClick={() => this.showCustomToaster({
+                  content: "This toaster is open!",
+                  autoClose: false
+                })}>Show Toaster</Button>
+              </GuideExample>
+              <GuideExample label='closeToaster() (All toasters)'>
+                <Button onClick={() => this.closeToaster()
+                }>Close All Toasters</Button>
+              </GuideExample>
+              <GuideExample label='closeToaster(toastId) (Only most recent toaster)'>
+                <Button onClick={() => {
+                  const { displayedToasterIds } = this.state
+                  const mostRecentToaster = displayedToasterIds[displayedToasterIds.length - 1]
+                    this.closeToaster(mostRecentToaster)
+                  }
+                }>Close All Toasters</Button>
+              </GuideExample>
+            </Fragment>
           );
         }
       }

--- a/src/Toaster/index.js
+++ b/src/Toaster/index.js
@@ -11,7 +11,7 @@
 
 export { default } from './Toaster';
 export { notify } from './Toaster';
-export { closeDisplayedToast } from './Toaster';
+export { toast } from './Toaster';
 export { default as ToastContainer } from './ToastContainer';
 export {
   StyledAlertTitle as ToastTitle,

--- a/src/Toaster/index.js
+++ b/src/Toaster/index.js
@@ -11,6 +11,7 @@
 
 export { default } from './Toaster';
 export { notify } from './Toaster';
+export { closeDisplayedToast } from './Toaster';
 export { default as ToastContainer } from './ToastContainer';
 export {
   StyledAlertTitle as ToastTitle,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Export `toast` object imported from `react-toastify` to give users access to increased `toast` methods.  
* Return toastId from notify() function.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#457 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Exporting `toast` object gives users access to `react-toastify` functionality without requiring users to separately install `react-toastify` dependency.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
