### PR TITLE
Hotfix - Add option to pass onRequestClose to ArcgisAccount

### DIFF
--- a/src/ArcgisAccount/ArcgisAccount.js
+++ b/src/ArcgisAccount/ArcgisAccount.js
@@ -94,6 +94,7 @@ class ArcgisAccount extends Component {
       token,
       onRequestSwitchAccount,
       onRequestSignOut,
+      onRequestClose,
       children,
       hideSwitchAccount,
       switchAccountLabel,
@@ -120,7 +121,7 @@ class ArcgisAccount extends Component {
           />
         }
         open={this.state.open}
-        onRequestClose={this.closeAccountControl}
+        onRequestClose={onRequestClose || this.closeAccountControl}
         placement="bottom-end"
         positionFixed
         appendToBody={appendToBody}

--- a/src/ArcgisAccount/ArcgisAccount.js
+++ b/src/ArcgisAccount/ArcgisAccount.js
@@ -121,7 +121,9 @@ class ArcgisAccount extends Component {
           />
         }
         open={this.state.open}
-        onRequestClose={onRequestClose || this.closeAccountControl}
+        onRequestClose={() => {
+          onRequestClose ? onRequestClose(this.closeAccountControl) : this.closeAccountControl()
+        }}
         placement="bottom-end"
         positionFixed
         appendToBody={appendToBody}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Popover issue where `onRequestClose` fires immediately after opening is present when react-dom is at version 17 or later
- The pure Popover component offers the ability to pass in a custom `onRequestClose` handler, but ArcgisAccount does not
- This hotfix presents a temporary workaround wherein a custom `onRequestClose` can be passed into ArcgisAccount and served to the Popover

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Related to issue #469 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Temporary fix while a more solid fix is developed in time

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
