### PR TITLE
Enable passthrough of custom title renderer into ArcgisItemCard

### DIFF
--- a/src/ArcgisItemCard/ArcgisItemCard.js
+++ b/src/ArcgisItemCard/ArcgisItemCard.js
@@ -130,7 +130,7 @@ ArcgisItemCard.propTypes = {
   /** Whether the ArcgisItemCard shows an actions tab at the bottom or not */
   actions: PropTypes.object,
   /** Whether the ArcgisItemCard should render the title differently */
-  customTitleRenderer: PropTypes.object
+  customTitleRenderer: PropTypes.func
 };
 
 ArcgisItemCard.defaultProps = {

--- a/src/ArcgisItemCard/ArcgisItemCard.js
+++ b/src/ArcgisItemCard/ArcgisItemCard.js
@@ -129,7 +129,7 @@ ArcgisItemCard.propTypes = {
   vertical: PropTypes.bool,
   /** Whether the ArcgisItemCard shows an actions tab at the bottom or not */
   actions: PropTypes.object,
-  /** Whether the ArcgisItemCard should render the title differently */
+  /** Function to render custom elements or values in the item card title */
   customTitleRenderer: PropTypes.func
 };
 

--- a/src/ArcgisItemCard/ArcgisItemCard.js
+++ b/src/ArcgisItemCard/ArcgisItemCard.js
@@ -34,6 +34,7 @@ const ArcgisItemCard = ({
   token,
   vertical,
   actions,
+  customTitleRenderer,
   ...other
 }) => {
   let imageEl;
@@ -88,7 +89,11 @@ const ArcgisItemCard = ({
       {imageEl}
       <StyledItemCardContent>
         <StyledCardItemTitle title={item.title}>
-          {_textShortener(item.title, 70)}
+          {customTitleRenderer ? (
+            customTitleRenderer(_textShortener(item.title, 70))
+          ) : (
+            <>{_textShortener(item.title, 70)}</>
+          )}
         </StyledCardItemTitle>
         <StyledCardItemMetrics>
           <StyledCardItemIconLabelText>
@@ -123,7 +128,9 @@ ArcgisItemCard.propTypes = {
   /** Style prop to position Card content vertically */
   vertical: PropTypes.bool,
   /** Whether the ArcgisItemCard shows an actions tab at the bottom or not */
-  actions: PropTypes.object
+  actions: PropTypes.object,
+  /** Whether the ArcgisItemCard should render the title differently */
+  customTitleRenderer: PropTypes.object
 };
 
 ArcgisItemCard.defaultProps = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Provides option for user to customize how the ArcgisItemCard title presents/behaves
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Resolves issue #473
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Gives user more options to customize item card presentation/behavior
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- npm packed a local version of calcite-react with the changes
- installed into arcgis-item-browser and tested passing a custom title renderer function into the arcgisItemCard component
## Screenshots (if appropriate):
**Example turning the item card title into a link:**
<img width="270" alt="Screen Shot 2021-05-26 at 12 52 11 PM" src="https://user-images.githubusercontent.com/21701076/119722460-30fcbc80-be21-11eb-89a8-35f7c88ccbd8.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
