### PR TITLE
Add default thumbnail prop for ArcgisItemCard

### DIFF
--- a/src/ArcgisItemCard/ArcgisItemCard.js
+++ b/src/ArcgisItemCard/ArcgisItemCard.js
@@ -35,15 +35,19 @@ const ArcgisItemCard = ({
   vertical,
   actions,
   customTitleRenderer,
+  defaultThumbnailUrl,
   ...other
 }) => {
   let imageEl;
   let hostname = portal ? portal.portalHostname : 'arcgis.com';
   if (showThumbnail) {
     const tokenUrlParam = token ? `?token=${token}` : '';
-    const imageSource = `https://${hostname}/sharing/rest/content/items/${
-      item.id
-    }/info/${item.thumbnail}${tokenUrlParam}`;
+    const imageSource =
+      item.thumbnail || !defaultThumbnailUrl
+        ? `https://${hostname}/sharing/rest/content/items/${item.id}/info/${
+            item.thumbnail
+          }${tokenUrlParam}`
+        : defaultThumbnailUrl;
     imageEl = (
       <StyledItemCardImageWrap vertical={vertical} imageSource={imageSource} />
     );
@@ -130,7 +134,9 @@ ArcgisItemCard.propTypes = {
   /** Whether the ArcgisItemCard shows an actions tab at the bottom or not */
   actions: PropTypes.object,
   /** Function to render custom elements or values in the item card title */
-  customTitleRenderer: PropTypes.func
+  customTitleRenderer: PropTypes.func,
+  /** String source URL to serve as default image for invalid thumbnails */
+  defaultThumbnailUrl: PropTypes.string
 };
 
 ArcgisItemCard.defaultProps = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Enables user to pass a `defaultThumbnailUrl` image source to ArcgisItemCard
- This optional value takes the place of a null/absent `item.thumbnail` to give users control over default item card thumbnails

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Resolves #477 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- ArcGIS Assistant uses arcgis-item-browser, which uses calcite-react's ArcgisItemCard
- ArcGIS Assistant has a default thumbnail behavior similar to ArcGIS Online, but different than ArcgisItemCard
- This change allows for the arcgis-item-browser to use the same default thumbnail as Arcgis Assistant, improving visual consistency for the ItemGrid and ItemList views
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Ran npm pack on this modified version of calcite-react
- Installed the package into arcgis-item-browser
- Searched for an item that has a known null thumbnail
## Screenshots (if appropriate):
**Before changes:**
![Screen Shot 2021-06-07 at 2 13 57 PM](https://user-images.githubusercontent.com/21701076/121088432-9b571a80-c79a-11eb-8064-155340e6ad73.png)
**After changes:**
![Screen Shot 2021-06-07 at 2 13 38 PM](https://user-images.githubusercontent.com/21701076/121088407-91351c00-c79a-11eb-986d-45ecc4e5259a.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
