### PR TITLE
Add docs for testing locally with `npm pack`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ To get started, go ahead and fork this repo. Once you've done that, there are a 
 
 ## Testing
 
-If you're having trouble using `npm link` to test calcite-react changes in a parent app, here is an alternative approach: After saving your changes and building for production, run `npm pack` in your calcite-react/dist folder. This will create a `/calcite-react/dist/calcite-react-[version].tgz` file that mimics a npm-published calcite-react package. Then run `npm install /path/to/file/calcite-react-[version].tgz` from your parent app to install the package locally and start test driving the changes.
+After saving your changes and building for production, run `npm pack` in your dist folder to create a .tgz file that mimics a npm-published calcite-react package. Then run `npm install [filename].tgz` from your parent app to install the package locally and test drive the changes.
 
 ## Submitting a Pull Request
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ To get started, go ahead and fork this repo. Once you've done that, there are a 
 
 ## Testing
 
-After saving your changes and building for production, run `npm pack` in the dist folder to create a .tgz file that mimics a npm-published calcite-react package. Then run `npm install [filename].tgz` from your parent app to install the package locally and test drive the changes.
+To test a local build of calcite-react from your own parent application, run `npm pack` in the dist folder to create a .tgz file that mimics a npm-published calcite-react package. Then run `npm install [filename].tgz` from your parent app to install the package locally and test drive the changes.
 
 ## Submitting a Pull Request
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ To get started, go ahead and fork this repo. Once you've done that, there are a 
 
 ## Testing
 
-To test a local build of calcite-react from your own parent application, run `npm pack` in the dist folder to create a .tgz file that mimics a npm-published calcite-react package. Then run `npm install [filename].tgz` from your parent app to install the package locally and test drive the changes.
+To test a local build of calcite-react from your own parent application, first run `npm run build` to generate the dist folder, then run `npm pack` in the dist folder to create a .tgz file that mimics a npm-published calcite-react package. Finally, run `npm install [filename].tgz` from your parent app to install the package locally and test drive the changes.
 
 ## Submitting a Pull Request
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,10 @@ To get started, go ahead and fork this repo. Once you've done that, there are a 
 
 `npm run build`
 
+## Testing
+
+If you're having trouble using `npm link` to test calcite-react changes in a parent app, here is an alternative approach: After saving your changes and building for production, run `npm pack` in your calcite-react/dist folder. This will create a `/calcite-react/dist/calcite-react-[version].tgz` file that mimics a npm-published calcite-react package. Then run `npm install /path/to/file/calcite-react-[version].tgz` from your parent app to install the package locally and start test driving the changes.
+
 ## Submitting a Pull Request
 
 Once you're ready to submit your changes, submit a pull request **into the `develop` branch**. Often it's a good idea to open an issue to discuss your proposed changes before making a PR, but you're welcome to submit a PR without an issue - just be sure to include a good description of your changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ To get started, go ahead and fork this repo. Once you've done that, there are a 
 
 ## Testing
 
-After saving your changes and building for production, run `npm pack` in your dist folder to create a .tgz file that mimics a npm-published calcite-react package. Then run `npm install [filename].tgz` from your parent app to install the package locally and test drive the changes.
+After saving your changes and building for production, run `npm pack` in the dist folder to create a .tgz file that mimics a npm-published calcite-react package. Then run `npm install [filename].tgz` from your parent app to install the package locally and test drive the changes.
 
 ## Submitting a Pull Request
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Adds documentation for `npm pack` testing workflow to assist developers in testing local changes to calcite-react in a parent application
* This approach serves as an alternative to the commonly referenced `npm link`, which can be cumbersome to implement in some environments 