### PR TITLE
0.61.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,10 @@ To get started, go ahead and fork this repo. Once you've done that, there are a 
 
 `npm run build`
 
+## Testing
+
+To test a local build of calcite-react from your own parent application, first run `npm run build` to generate the dist folder, then run `npm pack` in the dist folder to create a .tgz file that mimics a npm-published calcite-react package. Finally, run `npm install [filename].tgz` from your parent app to install the package locally and test drive the changes.
+
 ## Submitting a Pull Request
 
 Once you're ready to submit your changes, submit a pull request **into the `develop` branch**. Often it's a good idea to open an issue to discuss your proposed changes before making a PR, but you're welcome to submit a PR without an issue - just be sure to include a good description of your changes.

--- a/src/ArcgisItemCard/ArcgisItemCard.js
+++ b/src/ArcgisItemCard/ArcgisItemCard.js
@@ -35,15 +35,19 @@ const ArcgisItemCard = ({
   vertical,
   actions,
   customTitleRenderer,
+  defaultThumbnailUrl,
   ...other
 }) => {
   let imageEl;
   let hostname = portal ? portal.portalHostname : 'arcgis.com';
   if (showThumbnail) {
     const tokenUrlParam = token ? `?token=${token}` : '';
-    const imageSource = `https://${hostname}/sharing/rest/content/items/${
-      item.id
-    }/info/${item.thumbnail}${tokenUrlParam}`;
+    const imageSource =
+      item.thumbnail || !defaultThumbnailUrl
+        ? `https://${hostname}/sharing/rest/content/items/${item.id}/info/${
+            item.thumbnail
+          }${tokenUrlParam}`
+        : defaultThumbnailUrl;
     imageEl = (
       <StyledItemCardImageWrap vertical={vertical} imageSource={imageSource} />
     );
@@ -130,7 +134,9 @@ ArcgisItemCard.propTypes = {
   /** Whether the ArcgisItemCard shows an actions tab at the bottom or not */
   actions: PropTypes.object,
   /** Function to render custom elements or values in the item card title */
-  customTitleRenderer: PropTypes.func
+  customTitleRenderer: PropTypes.func,
+  /** String source URL to serve as default image for invalid thumbnails */
+  defaultThumbnailUrl: PropTypes.string
 };
 
 ArcgisItemCard.defaultProps = {


### PR DESCRIPTION
## Description
- Enables user to pass an image source URL to `defaultThumbnailUrl`
- This optional value takes the place of a null/absent `item.thumbnail` to give users control over default item card thumbnails
- Add documentation for testing Calcite React builds locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.