### PR TITLE
fix: correct the destructuring error with `setActive` prop

### DIFF
--- a/src/ArcgisAccount/accountManagerStorageUtils.js
+++ b/src/ArcgisAccount/accountManagerStorageUtils.js
@@ -15,7 +15,11 @@ export const getAccountManagerStorage = manager => {
 
 export const addAccountStorage = (manager, account) => {
   const previous = getLocalSerialized(manager);
-  const { accounts, active, status: setActive } = previous || {};
+  const {
+    accounts,
+    active,
+    status: { setActive }
+  } = previous || {};
   const updateActive = setActive || !active ? account.key : active;
   const order = previous.order
     ? previous.order.find(id => id === account.key)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- `previous` was destructured incorrectly, resulting in `setActive` holding all of the `status` object instead of the single `setActive` property
- I have corrected the destructuring format to simply assign `setActive` to the `setActive` object from `status` instead of assigning all of `status` to `setActive`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Resolves Bug #481

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Helps achieve the capability wherein users can add an account without making the account immediately active
- Assists in the development of an Arcgis-Assistant feature where users can add accounts in the middle of a copy-item workflow

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Run `npm pack` on the dist folder of calcite-react with these changes
- Run `npm install` from Assistant to install the self packaged version of calcite-react
- Perform a login where the setActive argument is false
- Observe that logins are completed successfully and the accounts are not immediately made active

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
