### PR TITLE
v0.62.0

### DIFF
--- a/src/AccountTile/AccountTile-styled.js
+++ b/src/AccountTile/AccountTile-styled.js
@@ -20,6 +20,7 @@ import { CalciteTheme as theme } from '../CalciteThemeProvider';
 
 // Calcite components
 import { CalciteP } from '../Elements';
+import HandleVerticalIcon from 'calcite-ui-icons-react/HandleVerticalIcon';
 import Avatar from '../Avatar';
 
 const StyledAccountTile = styled.div`
@@ -32,7 +33,8 @@ const StyledAccountTile = styled.div`
   background-color: ${props =>
     props.open ? props.theme.palette.offWhite : props.theme.palette.white};
 
-  ${props => props.clickable &&
+  ${props =>
+    props.clickable &&
     css`
       &:hover {
         background-color: ${props.theme.palette.offWhite};
@@ -73,7 +75,6 @@ const StyledP = styled(CalciteP)`
 `;
 
 const StyledIconWrapper = styled.span`
-  width: 48px;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -86,6 +87,10 @@ const StyledTextWrapper = styled.span`
   overflow: hidden;
 `;
 
+const StyledHandleVerticalIcon = styled(HandleVerticalIcon)`
+  margin-left: ${props => (props.marginLeft ? '0.5rem' : '0')};
+`;
+
 export {
   StyledAccountTile,
   StyledContentWrapper,
@@ -93,5 +98,6 @@ export {
   StyledOrgAvatar,
   StyledIconWrapper,
   StyledTextWrapper,
-  StyledP
+  StyledP,
+  StyledHandleVerticalIcon
 };

--- a/src/AccountTile/AccountTile.js
+++ b/src/AccountTile/AccountTile.js
@@ -20,7 +20,8 @@ import {
   StyledOrgAvatar,
   StyledIconWrapper,
   StyledTextWrapper,
-  StyledP
+  StyledP,
+  StyledHandleVerticalIcon
 } from './AccountTile-styled';
 
 import Avatar from '../Avatar';
@@ -29,7 +30,6 @@ import { MenuItem } from '../Menu';
 import Popover from '../Popover';
 import Menu from '../Menu';
 
-import HandleVerticalIcon from 'calcite-ui-icons-react/HandleVerticalIcon';
 import CheckCircleIcon from 'calcite-ui-icons-react/CheckCircleIcon';
 import ExclamationMarkTriangleIcon from 'calcite-ui-icons-react/ExclamationMarkTriangleIcon';
 
@@ -44,7 +44,7 @@ const AccountTile = ({
   expiredText,
   authenticatedText,
   clickable,
-  hideIcons,
+  hideAuthentication,
   ...other
 }) => {
   const [isOpen, setIsOpen] = useState(false);
@@ -135,8 +135,8 @@ const AccountTile = ({
               </StyledP>
             </StyledTextWrapper>
           </StyledContentWrapper>
-          {!hideIcons && (
-            <StyledIconWrapper>
+          <StyledIconWrapper>
+            {!hideAuthentication && (
               <Tooltip
                 title={isAuthenticated ? authenticatedText : expiredText}
                 placement="top"
@@ -159,9 +159,14 @@ const AccountTile = ({
                   />
                 )}
               </Tooltip>
-              {actions.length !== 0 && <HandleVerticalIcon scale={16} />}
-            </StyledIconWrapper>
-          )}
+            )}
+            {clickable && actions.length !== 0 && (
+              <StyledHandleVerticalIcon
+                scale={16}
+                marginLeft={!hideAuthentication}
+              />
+            )}
+          </StyledIconWrapper>
         </StyledAccountTile>
       }
     >
@@ -202,8 +207,8 @@ AccountTile.propTypes = {
   }),
   /** Can the time be clicked (false will disable hover effects and pointer events) */
   clickable: PropTypes.bool,
-  /** Should the account tiles be hidden */
-  hideIcons: PropTypes.bool
+  /** Should the account tile authentication be hidden */
+  hideAuthentication: PropTypes.bool
 };
 
 AccountTile.defaultProps = {
@@ -213,7 +218,7 @@ AccountTile.defaultProps = {
   authenticatedText: 'Signed in',
   expiredText: 'Session expired',
   clickable: true,
-  hideIcons: false
+  hideAuthentication: false
 };
 
 AccountTile.displayName = 'AccountTile';

--- a/src/AccountTile/doc/AccountTile.mdx
+++ b/src/AccountTile/doc/AccountTile.mdx
@@ -111,7 +111,7 @@ import AccountTile from 'calcite-react/AccountTile';
           userThumbnail={placeholders.userThumbnail}
           orgThumbnail={placeholders.orgThumbnail}
           clickable={false}
-          hideIcons={true}
+          hideAuthentication={true}
         />
       );
     }

--- a/src/ArcgisAccount/accountManagerStorageUtils.js
+++ b/src/ArcgisAccount/accountManagerStorageUtils.js
@@ -15,7 +15,11 @@ export const getAccountManagerStorage = manager => {
 
 export const addAccountStorage = (manager, account) => {
   const previous = getLocalSerialized(manager);
-  const { accounts, active, status: setActive } = previous || {};
+  const {
+    accounts,
+    active,
+    status: { setActive }
+  } = previous || {};
   const updateActive = setActive || !active ? account.key : active;
   const order = previous.order
     ? previous.order.find(id => id === account.key)

--- a/src/Radio/Radio-styled.js
+++ b/src/Radio/Radio-styled.js
@@ -27,6 +27,7 @@ import { CalciteTheme as theme } from '../CalciteThemeProvider';
 
 const StyledRadio = styled(baseRadioCheckbox)`
   -webkit-appearance: radio;
+  flex-shrink: 0;
   border-radius: 50%;
   margin-right: ${props => unitCalc(props.theme.baseline, 4, '/')};
   cursor: pointer;


### PR DESCRIPTION
## Description
- `previous` was destructured incorrectly, resulting in `setActive` holding all of the `status` object instead of the single `setActive` property
- Prevent radio buttons from shrinking
- Account tile action updates

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
