### PR TITLE
Fix search icon rtl position for TextField

### DIFF
--- a/src/utils/commonElements.js
+++ b/src/utils/commonElements.js
@@ -248,7 +248,7 @@ const input = styled(formSelectInputTextarea)`
     const bgPos = [];
     props.success && bgPos.push(`right center`);
     props.error && bgPos.push(`right center`);
-    props.search && bgPos.push(`0.25rem center`);
+    props.search && bgPos.push(`left 0.25rem center`);
     return bgPos.join(', ');
   }};
 
@@ -269,7 +269,7 @@ const input = styled(formSelectInputTextarea)`
       const bgPos = [];
       props.success && bgPos.push(`left center`);
       props.error && bgPos.push(`left center`);
-      props.search && bgPos.push(`0.25em center`);
+      props.search && bgPos.push(`right 0.25em center`);
       return bgPos.join(', ');
     }};
   }


### PR DESCRIPTION
Flip the search icon for `TextField` to the right for rtl languages

## Description
This PR enhances the `background-position` by [specifying the horizontal edge](https://drafts.csswg.org/css-backgrounds-3/#background-position) for both scenarios (rtl and ltr)

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
Currently when `<html dir="rtl" ...>` is set the error and success icons are flipped from right to left but the search icon is not flipped from left to right:
![Screen Shot 2021-08-13 at 09 41 28](https://user-images.githubusercontent.com/5748802/129323109-35a086e6-e6e5-45a4-9154-291141a5d427.png)

With these changes to search icon will also be flipped:
![Screen Shot 2021-08-13 at 09 45 12](https://user-images.githubusercontent.com/5748802/129323099-08c4105f-fe27-4697-9f96-bf2e54a841e1.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
